### PR TITLE
Make KeyValueStore closeable

### DIFF
--- a/kv/src/main/kotlin/net/consensys/cava/kv/KeyValueStore.kt
+++ b/kv/src/main/kotlin/net/consensys/cava/kv/KeyValueStore.kt
@@ -20,12 +20,13 @@ import net.consensys.cava.concurrent.AsyncCompletion
 import net.consensys.cava.concurrent.AsyncResult
 import net.consensys.cava.concurrent.coroutines.experimental.asyncCompletion
 import net.consensys.cava.concurrent.coroutines.experimental.asyncResult
+import java.io.Closeable
 import java.util.Optional
 
 /**
  * A key-value store.
  */
-interface KeyValueStore {
+interface KeyValueStore : Closeable {
 
   /**
    * Retrieves data from the store.

--- a/kv/src/main/kotlin/net/consensys/cava/kv/LevelDBKeyValueStore.kt
+++ b/kv/src/main/kotlin/net/consensys/cava/kv/LevelDBKeyValueStore.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.experimental.withContext
 import net.consensys.cava.bytes.Bytes
 import org.fusesource.leveldbjni.JniDBFactory
 import org.iq80.leveldb.Options
-import java.io.Closeable
 import java.nio.file.Path
 
 /**
@@ -30,7 +29,7 @@ class LevelDBKeyValueStore
 @JvmOverloads constructor(
   databasePath: Path,
   options: Options = Options().createIfMissing(true).cacheSize((100 * 1048576).toLong())
-) : KeyValueStore, Closeable {
+) : KeyValueStore {
 
   private val db = JniDBFactory.factory.open(databasePath.toFile(), options)
 

--- a/kv/src/main/kotlin/net/consensys/cava/kv/MapDBKeyValueStore.kt
+++ b/kv/src/main/kotlin/net/consensys/cava/kv/MapDBKeyValueStore.kt
@@ -19,13 +19,12 @@ import net.consensys.cava.bytes.Bytes
 import org.mapdb.DBMaker
 import org.mapdb.DataInput2
 import org.mapdb.DataOutput2
-import java.io.Closeable
 import java.nio.file.Path
 
 /**
  * A key-value store backed by a MapDB instance.
  */
-class MapDBKeyValueStore(databasePath: Path) : KeyValueStore, Closeable {
+class MapDBKeyValueStore(databasePath: Path) : KeyValueStore {
 
   private val db = DBMaker.fileDB(databasePath.toFile()).transactionEnable().closeOnJvmShutdown().make()
   private val storageData = db.hashMap("storageData", BytesSerializer(), BytesSerializer()).createOrOpen()

--- a/kv/src/main/kotlin/net/consensys/cava/kv/MapKeyValueStore.kt
+++ b/kv/src/main/kotlin/net/consensys/cava/kv/MapKeyValueStore.kt
@@ -27,4 +27,9 @@ class MapKeyValueStore(private val map: MutableMap<Bytes, Bytes>) : KeyValueStor
   override suspend fun put(key: Bytes, value: Bytes) {
     map[key] = value
   }
+
+  /**
+   * Has no effect in this KeyValueStore implementation.
+   */
+  override fun close() {}
 }


### PR DESCRIPTION
This pulls the Closeable inheritance up to the KeyValueStore interface.

All implementations must, therefore, provide an implementation, which for MapKeyValueStore means a no-op.