### PR TITLE
Add Redis backend support for key/value storage

### DIFF
--- a/dependency-versions.gradle
+++ b/dependency-versions.gradle
@@ -1,9 +1,11 @@
 dependencyManagement {
   dependencies {
     dependency('com.github.jnr:jnr-ffi:2.1.8')
+    dependency('com.github.kstyrc:embedded-redis:0.6')
     dependency('com.google.errorprone:error_prone_core:2.3.1')
     dependency('com.google.guava:guava:25.1-jre')
     dependency('com.winterbe:expekt:0.5.0')
+    dependency('io.lettuce:lettuce-core:5.1.0.M1')
     dependency('io.vertx:vertx-core:3.5.2')
     dependency('com.google.code.findbugs:jsr305:3.0.2')
     dependency('org.antlr:antlr4:4.7.1')

--- a/gradle/check-licenses.gradle
+++ b/gradle/check-licenses.gradle
@@ -17,6 +17,7 @@
 ext.acceptedLicenses = [
   'Apache License, Version 2.0',
   'Bouncy Castle Licence',
+  'CC0',
   'The 2-Clause BSD License',
   'The 3-Clause BSD License',
   'Common Development and Distribution License 1.0',

--- a/junit/build.gradle
+++ b/junit/build.gradle
@@ -2,10 +2,13 @@ description = 'Utilities for better junit testing.'
 
 dependencies {
   compile project(':io')
+  compileOnly 'com.github.kstyrc:embedded-redis'
   compileOnly 'io.vertx:vertx-core'
   compileOnly 'org.bouncycastle:bcprov-jdk15on'
   compileOnly 'org.junit.jupiter:junit-jupiter-api'
 
+  testCompile 'com.github.kstyrc:embedded-redis'
+  testCompile 'io.lettuce:lettuce-core'
   testCompile 'org.junit.jupiter:junit-jupiter-api'
   testCompile 'org.junit.jupiter:junit-jupiter-params'
 

--- a/junit/src/main/java/net/consensys/cava/junit/RedisPort.java
+++ b/junit/src/main/java/net/consensys/cava/junit/RedisPort.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A parameter annotation for injecting the running Redis server port into junit5 tests.
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RedisPort {
+
+}

--- a/junit/src/main/java/net/consensys/cava/junit/RedisServerExtension.java
+++ b/junit/src/main/java/net/consensys/cava/junit/RedisServerExtension.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.junit;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.security.SecureRandom;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import redis.embedded.RedisServer;
+
+/**
+ * A junit5 extension, that sets up an ephemeral Redis server for tests.
+ *
+ * The ephemeral Redis server is created with a random free port for the test suite and injected into any tests with
+ * parameters of type {@link Integer} annotated with {@link RedisPort}
+ *
+ * NOTE: Redis does not support picking a random port on its own. This extension tries its best to test free ports and
+ * avoid collisions.
+ */
+public final class RedisServerExtension implements ParameterResolver, AfterAllCallback {
+
+  private static Set<Integer> rangesIssued = ConcurrentHashMap.newKeySet();
+  private static SecureRandom random = new SecureRandom();
+
+  private static int findFreeRange() {
+    int range = random.nextInt(326);
+    if (!rangesIssued.add(range)) {
+      return findFreeRange();
+    }
+    return range;
+  }
+
+  private static int findFreePort() {
+    int range = findFreeRange() * 100 + 32768;
+    int port = range;
+    while (port < range + 100) {
+      try {
+        ServerSocket socket = new ServerSocket(port, 0, InetAddress.getLocalHost());
+        socket.setReuseAddress(false);
+        socket.close();
+        return port;
+      } catch (IOException e) {
+        port++;
+      }
+    }
+    throw new IllegalStateException("Could not reserve a port in range " + range + " and " + range + 100);
+  }
+
+  private RedisServer redisServer;
+
+  private Thread shutdownThread = new Thread(() -> {
+    if (redisServer != null) {
+      redisServer.stop();
+    }
+  });
+
+  @Override
+  public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    return Integer.class.equals(parameterContext.getParameter().getType())
+        && parameterContext.isAnnotated(RedisPort.class);
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    if (redisServer == null) {
+      String localhost = InetAddress.getLoopbackAddress().getHostAddress();
+
+      redisServer = RedisServer
+          .builder()
+          .setting("bind " + localhost)
+          .setting("maxmemory 128mb")
+          .setting("maxmemory-policy allkeys-lru")
+          .setting("appendonly no")
+          .setting("save \"\"")
+          .port(findFreePort())
+          .build();
+      Runtime.getRuntime().addShutdownHook(shutdownThread);
+      redisServer.start();
+    }
+    return redisServer.ports().get(0);
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) {
+    if (redisServer != null) {
+      redisServer.stop();
+      Runtime.getRuntime().removeShutdownHook(shutdownThread);
+    }
+  }
+}

--- a/junit/src/test/java/net/consensys/cava/junit/RedisServerExtensionTest.java
+++ b/junit/src/test/java/net/consensys/cava/junit/RedisServerExtensionTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.junit;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.InetAddress;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulRedisConnection;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(RedisServerExtension.class)
+class RedisServerExtensionTest {
+
+  @Test
+  void shouldHaveAccessToARedisServer(@RedisPort Integer port) {
+    assertNotNull(port);
+    assertTrue(port > 32768);
+    RedisClient client = RedisClient.create(RedisURI.create(InetAddress.getLoopbackAddress().getHostAddress(), port));
+    try (StatefulRedisConnection<String, String> conn = client.connect()) {
+      assertTrue(conn.isOpen());
+    }
+  }
+}

--- a/kv/build.gradle
+++ b/kv/build.gradle
@@ -5,12 +5,15 @@ dependencies {
   compileOnly project(':concurrent')
   compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core'
 
+  compileOnly 'io.lettuce:lettuce-core'
   compileOnly 'org.fusesource.leveldbjni:leveldbjni-all'
   compileOnly 'org.mapdb:mapdb'
 
   testCompile project(':concurrent')
   testCompile project(':junit')
+  testCompile 'com.github.kstyrc:embedded-redis'
   testCompile 'com.winterbe:expekt'
+  testCompile 'io.lettuce:lettuce-core'
   testCompile 'org.fusesource.leveldbjni:leveldbjni-all'
   testCompile 'org.jetbrains.spek:spek-api'
   testCompile 'org.junit.jupiter:junit-jupiter-api'

--- a/kv/src/main/kotlin/net/consensys/cava/kv/RedisKeyValueStore.kt
+++ b/kv/src/main/kotlin/net/consensys/cava/kv/RedisKeyValueStore.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.kv
+
+import io.lettuce.core.RedisClient
+import io.lettuce.core.RedisURI
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.async.RedisAsyncCommands
+import io.lettuce.core.codec.RedisCodec
+import net.consensys.cava.bytes.Bytes
+import java.net.InetAddress
+import java.nio.ByteBuffer
+
+class RedisKeyValueStore(uri: String)
+  : KeyValueStore {
+
+  private val conn: StatefulRedisConnection<Bytes, Bytes>
+  private val asyncCommands: RedisAsyncCommands<Bytes, Bytes>
+
+  @JvmOverloads
+  constructor(
+    port: Int = 6379,
+    networkInterface: InetAddress = InetAddress.getLoopbackAddress()
+  ) : this(RedisURI.create(networkInterface.hostAddress, port).toURI().toString())
+
+  init {
+    val redisClient = RedisClient.create(uri)
+    conn = redisClient.connect(BytesRedisCodec())
+    asyncCommands = conn.async()
+  }
+
+  override suspend fun get(key: Bytes): Bytes? {
+    return asyncCommands.get(key).get()
+  }
+
+  override suspend fun put(key: Bytes, value: Bytes) {
+    asyncCommands.set(key, value).get()
+  }
+
+  override fun close() {
+    conn.close()
+  }
+
+  class BytesRedisCodec : RedisCodec<Bytes, Bytes> {
+    override fun decodeKey(bytes: ByteBuffer?): Bytes? {
+      return if (bytes == null) {
+        null
+      } else {
+        Bytes.wrapByteBuffer(bytes)
+      }
+    }
+
+    override fun encodeValue(value: Bytes?): ByteBuffer {
+      return ByteBuffer.wrap(value?.toArrayUnsafe() ?: ByteArray(0))
+    }
+
+    override fun encodeKey(key: Bytes?): ByteBuffer {
+      return ByteBuffer.wrap(key?.toArrayUnsafe() ?: ByteArray(0))
+    }
+
+    override fun decodeValue(bytes: ByteBuffer?): Bytes? {
+      return if (bytes == null) {
+        null
+      } else {
+        Bytes.wrapByteBuffer(bytes)
+      }
+    }
+  }
+}

--- a/kv/src/test/java/net/consensys/cava/kv/RedisKeyValueStoreTest.java
+++ b/kv/src/test/java/net/consensys/cava/kv/RedisKeyValueStoreTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.kv;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.concurrent.AsyncCompletion;
+import net.consensys.cava.junit.RedisPort;
+import net.consensys.cava.junit.RedisServerExtension;
+import net.consensys.cava.kv.RedisKeyValueStore.BytesRedisCodec;
+
+import java.net.InetAddress;
+import java.util.Optional;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulRedisConnection;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(RedisServerExtension.class)
+class RedisKeyValueStoreTest {
+
+  @Test
+  void testPutAndGet(@RedisPort Integer redisPort) throws Exception {
+    KeyValueStore store = new RedisKeyValueStore(redisPort);
+    AsyncCompletion completion = store.putAsync(Bytes.of(123), Bytes.of(10, 12, 13));
+    completion.join();
+    Optional<Bytes> value = store.getAsync(Bytes.of(123)).get();
+    assertTrue(value.isPresent());
+    assertEquals(Bytes.of(10, 12, 13), value.get());
+    RedisClient client =
+        RedisClient.create(RedisURI.create(InetAddress.getLoopbackAddress().getHostAddress(), redisPort));
+    try (StatefulRedisConnection<Bytes, Bytes> conn = client.connect(new BytesRedisCodec())) {
+      assertEquals(Bytes.of(10, 12, 13), conn.sync().get(Bytes.of(123)));
+    }
+  }
+
+  @Test
+  void testNoValue(@RedisPort Integer redisPort) throws Exception {
+    KeyValueStore store = new RedisKeyValueStore(redisPort, InetAddress.getLoopbackAddress());
+    assertFalse(store.getAsync(Bytes.of(124)).get().isPresent());
+  }
+
+  @Test
+  void testRedisCloseable(@RedisPort Integer redisPort) throws Exception {
+    try (RedisKeyValueStore redis = new RedisKeyValueStore("redis://127.0.0.1:" + redisPort)) {
+      AsyncCompletion completion = redis.putAsync(Bytes.of(125), Bytes.of(10, 12, 13));
+      completion.join();
+      Optional<Bytes> value = redis.getAsync(Bytes.of(125)).get();
+      assertTrue(value.isPresent());
+      assertEquals(Bytes.of(10, 12, 13), value.get());
+    }
+  }
+}


### PR DESCRIPTION
This PR adds 2 elements:
* A junit5 extension to run a minimal, in-memory, redis server in a managed manner.
* A key/value store to create a simple Lettuce client that connects to a running redis server and executes storing and retrieval of values asynchronously.