### PR TITLE
Ability to listen to config files and reload the config whenever it changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ static String buildTag() {
 defaultTasks 'checkLicenses', 'spotlessCheck', 'jar', 'test', ':javadoc'
 
 def buildAliases = ['dev': [
+    ':skipSlowTests',
     'spotlessApply',
     'checkLicenses',
     ':jar',
@@ -68,6 +69,8 @@ spotless {
   }
 }
 
+task skipSlowTests() {}
+
 task deploy() {}
 
 allprojects {
@@ -91,8 +94,17 @@ allprojects {
   //////
   // Use JUnit5 for testing
 
-  test { useJUnitPlatform() { includeEngines 'spek', 'junit-jupiter' } }
+  test {
+    useJUnitPlatform() {
 
+      gradle.taskGraph.whenReady {
+        if (gradle.taskGraph.hasTask(':skipSlowTests')) {
+          excludeTags 'slow'
+        }
+      }
+      includeEngines 'spek', 'junit-jupiter'
+    }
+  }
 
   //////
   // Compiler arguments

--- a/config/build.gradle
+++ b/config/build.gradle
@@ -1,9 +1,11 @@
 description = 'Classes and utilities for working with configuration.'
 
 dependencies {
+  compile project(':io')
   compile project(':toml')
   compile 'com.google.guava:guava'
 
+  testCompile project(':junit')
   testCompile 'org.junit.jupiter:junit-jupiter-api'
   testCompile 'org.junit.jupiter:junit-jupiter-params'
 

--- a/config/src/test/java/net/consensys/cava/config/ConfigurationTest.java
+++ b/config/src/test/java/net/consensys/cava/config/ConfigurationTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.config;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import net.consensys.cava.junit.TempDirectory;
+import net.consensys.cava.junit.TempDirectoryExtension;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(TempDirectoryExtension.class)
+class ConfigurationTest {
+
+  @Tag("slow")
+  @Test
+  void reloadConfig(@TempDirectory Path tempDir) throws Exception {
+    Files.write(tempDir.resolve("config.toml"), "key=\"foo\"".getBytes(UTF_8));
+    AtomicReference<Configuration> newConfigReference = new AtomicReference<>();
+    Configuration config =
+        Configuration.fromToml(tempDir.resolve("config.toml"), (newConfig) -> newConfigReference.set(newConfig));
+    assertEquals("foo", config.get("key"));
+    Thread.sleep(500);
+    Files.write(tempDir.resolve("config.toml"), "key=\"bar\"".getBytes(UTF_8));
+    for (int i = 0; i < 30; i++) {
+      // by default, the polling mechanism of WatchService polls every 10s.
+      Thread.sleep(1000);
+      if (newConfigReference.get() != null) {
+        break;
+      }
+    }
+    assertNotNull(newConfigReference.get());
+    assertEquals("bar", newConfigReference.get().get("key"));
+
+  }
+
+}


### PR DESCRIPTION
This adds the ability to provide a consumer that is called with a new copy of the configuration whenever the file is changed. This is relying on the JDK's WatchService API, which uses polling (with a default polling interval of 10s) to listen to file system changes.
This functionality is decoupled between config and a new method in the io module that allows listening to file changes.
The tests added for this functionality are slow, as polling intervals cannot always be shortened. To make sure developers don't experience slow builds on their local machines, the tests are tagged with the slow tag and ignored when the "dev" task runs.