### PR TITLE
Support v0.5.0 version of TOML

### DIFF
--- a/toml/README.md
+++ b/toml/README.md
@@ -2,12 +2,24 @@
 
 Cava-Toml is a complete TOML parser with the following attributes:
 
-* Supports the latest TOML version (0.4).
+* Supports the latest TOML specification version (0.5.0).
 * Provides detailed error reporting, including error position.
 * Performs error recovery, allowing parsing to continue after an error.
 
 It uses the [ANTLR](https://github.com/antlr/antlr4/) parser-generator and
 runtime library.
+
+## Usage
+
+Parsing is straightforward:
+
+```
+Path source = Paths.get("/path/to/file.toml");
+TomlParseResult result = Toml.parse(source);
+result.errors().forEach(error -> System.err.println(error.toString()));
+
+String value = result.getString("a. dotted . key");
+```
 
 ## Getting Cava-Toml
 

--- a/toml/src/main/java/net/consensys/cava/toml/TomlVersion.java
+++ b/toml/src/main/java/net/consensys/cava/toml/TomlVersion.java
@@ -12,6 +12,8 @@
  */
 package net.consensys.cava.toml;
 
+import javax.annotation.Nullable;
+
 /**
  * Supported TOML specification versions.
  */
@@ -25,9 +27,17 @@ public enum TomlVersion {
    */
   V0_4_0(null),
   /**
+   * The 0.5.0 version of TOML.
+   *
+   * <p>
+   * This specification can be found at <a href=
+   * "https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.5.0.md">https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.5.0.md</a>.
+   */
+  V0_5_0(null),
+  /**
    * The latest stable specification of TOML.
    */
-  LATEST(V0_4_0),
+  LATEST(V0_5_0),
   /**
    * The head (development) specification of TOML.
    *
@@ -42,7 +52,7 @@ public enum TomlVersion {
 
   final TomlVersion canonical;
 
-  TomlVersion(TomlVersion canonical) {
+  TomlVersion(@Nullable TomlVersion canonical) {
     this.canonical = canonical != null ? canonical : this;
   }
 

--- a/toml/src/main/java/net/consensys/cava/toml/ValueVisitor.java
+++ b/toml/src/main/java/net/consensys/cava/toml/ValueVisitor.java
@@ -26,6 +26,8 @@ import net.consensys.cava.toml.internal.TomlParser.LocalTimeContext;
 import net.consensys.cava.toml.internal.TomlParser.OctIntContext;
 import net.consensys.cava.toml.internal.TomlParser.OffsetDateTimeContext;
 import net.consensys.cava.toml.internal.TomlParser.RegularFloatContext;
+import net.consensys.cava.toml.internal.TomlParser.RegularFloatInfContext;
+import net.consensys.cava.toml.internal.TomlParser.RegularFloatNaNContext;
 import net.consensys.cava.toml.internal.TomlParser.StringContext;
 import net.consensys.cava.toml.internal.TomlParser.TrueBoolContext;
 import net.consensys.cava.toml.internal.TomlParserBaseVisitor;
@@ -79,6 +81,16 @@ final class ValueVisitor extends TomlParserBaseVisitor<Object> {
   @Override
   public Object visitRegularFloat(RegularFloatContext ctx) {
     return toDouble(ctx.getText().replaceAll("_", ""), ctx);
+  }
+
+  @Override
+  public Object visitRegularFloatInf(RegularFloatInfContext ctx) {
+    return (ctx.getText().startsWith("-")) ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
+  }
+
+  @Override
+  public Object visitRegularFloatNaN(RegularFloatNaNContext ctx) {
+    return Double.NaN;
   }
 
   private Double toDouble(String s, ParserRuleContext ctx) {

--- a/toml/src/test/resources/net/consensys/cava/toml/toml-v0.5.0-spec-example.toml
+++ b/toml/src/test/resources/net/consensys/cava/toml/toml-v0.5.0-spec-example.toml
@@ -1,0 +1,33 @@
+# This is a TOML document.
+
+title = "TOML Example"
+
+[owner]
+name = "Tom Preston-Werner"
+dob = 1979-05-27T07:32:00-08:00 # First class dates
+
+[database]
+server = "192.168.1.1"
+ports = [ 8001, 8001, 8002 ]
+connection_max = 5000
+enabled = true
+
+[servers]
+
+  # Indentation (tabs and/or spaces) is allowed but not required
+  [servers.alpha]
+  ip = "10.0.0.1"
+  dc = "eqdc10"
+
+  [servers.beta]
+  ip = "10.0.0.2"
+  dc = "eqdc10"
+
+[clients]
+data = [ ["gamma", "delta"], [1, 2] ]
+
+# Line breaks are OK when inside arrays
+hosts = [
+  "alpha",
+  "omega"
+]


### PR DESCRIPTION
Added V0_5_0 version tag (most support was already available in the `HEAD` version).