### PR TITLE
Make sure signature recovery id is valid

### DIFF
--- a/crypto/src/main/java/net/consensys/cava/crypto/SECP256K1.java
+++ b/crypto/src/main/java/net/consensys/cava/crypto/SECP256K1.java
@@ -713,7 +713,7 @@ public final class SECP256K1 {
       MutableBytes encoded = MutableBytes.create(65);
       UInt256.valueOf(r).toBytes().copyTo(encoded, 0);
       UInt256.valueOf(s).toBytes().copyTo(encoded, 32);
-      encoded.set(64, v);
+      encoded.set(64, v == 27 || v == 28 ? (byte) (v - 27) : v);
       return encoded;
     }
 

--- a/crypto/src/test/java/net/consensys/cava/crypto/SECP256K1Test.java
+++ b/crypto/src/test/java/net/consensys/cava/crypto/SECP256K1Test.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
+import net.consensys.cava.crypto.SECP256K1.KeyPair;
 import net.consensys.cava.crypto.SECP256K1.PublicKey;
 import net.consensys.cava.crypto.SECP256K1.Signature;
 import net.consensys.cava.junit.BouncyCastleExtension;
@@ -312,5 +313,13 @@ class SECP256K1Test {
     Path tempFile = tempDir.resolve("tempId");
     Files.write(tempFile, "not\n\nvalid".getBytes(UTF_8));
     assertThrows(InvalidSEC256K1PrivateKeyStoreException.class, () -> SECP256K1.PrivateKey.load(tempFile));
+  }
+
+  @Test
+  void testEncodedBytes() {
+    KeyPair kp = SECP256K1.KeyPair.random();
+    Signature sig = SECP256K1.sign(Bytes.of(1, 2, 3), kp);
+    assertEquals(65, sig.encodedBytes().size());
+    assertTrue(sig.encodedBytes().get(64) <= 3 && sig.encodedBytes().get(64) >= 0);
   }
 }


### PR DESCRIPTION
When encoding to bytes, make sure to be in compliance with EIP155.