### PR TITLE
Make complete distribution depend on components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 .springBeans
 .vertx
 bin/
+classes/
 local.properties
 target/
 tmp/

--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -6,19 +6,19 @@ In the spirit of [Google Guava](https://github.com/google/guava/), Cava is a set
 
 Classes and utilities for working with byte arrays.
 
-These classes are included in the standard Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-bytes` (`cava-bytes.jar`).
+These classes are included in the complete Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-bytes` (`cava-bytes.jar`).
 
 # Package net.consensys.cava.concurrent
 
 Classes and utilities for working with concurrency.
 
-These classes are included in the standard Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-concurrent` (`cava-concurrent.jar`).
+These classes are included in the complete Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-concurrent` (`cava-concurrent.jar`).
 
 # Package net.consensys.cava.config
 
 A general-purpose library for managing configuration data.
 
-These classes are included in the standard Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-config` (`cava-config.jar`).
+These classes are included in the complete Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-config` (`cava-config.jar`).
 
 # Package net.consensys.cava.concurrent.coroutines.experimental
 
@@ -30,7 +30,7 @@ Note that these APIs are ready for production usage. The 'experimental' package 
 
 Classes and utilities for working with cryptography.
 
-These classes are included in the standard Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-crypto` (`cava-crypto.jar`).
+These classes are included in the complete Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-crypto` (`cava-crypto.jar`).
 
 # Package net.consensys.cava.crypto.sodium
 
@@ -38,19 +38,19 @@ Classes and utilities for working with the sodium native library.
 
 Classes and utilities in this package provide an interface to the native Sodium crypto library (https://www.libsodium.org/), which must be installed on the same system as the JVM. It will be searched for in common library locations, or its it can be loaded explicitly using [net.consensys.cava.crypto.sodium.Sodium.loadLibrary].
 
-Classes in this package also depend upon the JNR-FFI library being available on the classpath, along with its dependencies. See https://github.com/jnr/jnr-ffi. JNR-FFI can be included using the gradle dependency `com.github.jnr:jnr-ffi`.
+Classes in this package depend upon the JNR-FFI library, which is not automatically included when using the complete Cava distribution. See https://github.com/jnr/jnr-ffi. JNR-FFI can be included using the gradle dependency `com.github.jnr:jnr-ffi`.
 
 # Package net.consensys.cava.eth.domain
 
 Classes and utilities for working with Ethereum domain objects.
 
-These classes are included in the standard Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-eth-domain` (`cava-eth-domain.jar`).
+These classes are included in the complete Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-eth-domain` (`cava-eth-domain.jar`).
 
 # Package net.consensys.cava.io
 
 Classes and utilities for handling file and network IO.
 
-These classes are included in the standard Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-io` (`cava-io.jar`).
+These classes are included in the complete Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-io` (`cava-io.jar`).
 
 # Package net.consensys.cava.io.file
 
@@ -60,19 +60,21 @@ General utilities for working with files and the filesystem.
 
 Utilities for better junit testing.
 
-These classes are included in the standard Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-junit` (`cava-junit.jar`).
+These classes are included in the complete Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-junit` (`cava-junit.jar`).
 
 # Package net.consensys.cava.kv
 
 Classes and utilities for working with key/value stores.
 
-These classes are included in the standard Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-kv` (`cava-kv.jar`).
+These classes are included in the complete Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-kv` (`cava-kv.jar`).
+
+Classes in this package depend upon the kotlinx-coroutines library, which is not automatically included when using the complete Cava distrubution. See https://github.com/Kotlin/kotlinx.coroutines. kotlinx-coroutines can be included using the gradle dependency `com.jetbrains.kotlinx:koltinx-coroutines-core`.
 
 # Package net.consensys.cava.net
 
 Classes and utilities for working with networking.
 
-These classes are included in the standard Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-net` (`cava-net.jar`).
+These classes are included in the complete Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-net` (`cava-net.jar`).
 
 # Package net.consensys.cava.net.tls
 
@@ -84,7 +86,7 @@ Recursive Length Prefix (RLP) encoding and decoding.
 
 An implementation of the Ethereum Recursive Length Prefix (RLP) algorithm, as described at https://github.com/ethereum/wiki/wiki/RLP.
 
-These classes are included in the standard Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-rlp` (`cava-rlp.jar`).
+These classes are included in the complete Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-rlp` (`cava-rlp.jar`).
 
 # Package net.consensys.cava.toml
 
@@ -92,7 +94,7 @@ A parser for Tom's Obvious, Minimal Language (TOML).
 
 A parser and semantic checker for Tom's Obvious, Minimal Language (TOML), as described at https://github.com/toml-lang/toml/.
 
-These classes are included in the standard Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-toml` (cava-toml.jar).
+These classes are included in the complete Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-toml` (cava-toml.jar).
 
 # Package net.consensys.cava.trie
 
@@ -100,7 +102,9 @@ Merkle Trie implementations.
 
 Implementations of the Ethereum Patricia Trie, as described at https://github.com/ethereum/wiki/wiki/Patricia-Tree.
 
-These classes are included in the standard Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-merkle-trie` (`cava-merkle-trie.jar`).
+These classes are included in the complete Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-merkle-trie` (`cava-merkle-trie.jar`).
+
+Classes in this package depend upon the kotlinx-coroutines library, which is not automatically included when using the complete Cava distrubution. See https://github.com/Kotlin/kotlinx.coroutines. kotlinx-coroutines can be included using the gradle dependency `com.jetbrains.kotlinx:koltinx-coroutines-core`.
 
 # Package net.consensys.cava.trie.experimental
 
@@ -108,11 +112,13 @@ Merkle Trie implementations using Kotlin coroutines.
 
 Note that these APIs are ready for production usage. The 'experimental' package name reflects the experimental nature of the coroutines design in Kotlin, as described at https://kotlinlang.org/docs/reference/coroutines.html#experimental-status-of-coroutines.
 
+Classes in this package depend upon the kotlinx-coroutines library, which is not automatically included when using the complete Cava distrubution. See https://github.com/Kotlin/kotlinx.coroutines. kotlinx-coroutines can be included using the gradle dependency `com.jetbrains.kotlinx:koltinx-coroutines-core`.
+
 # Package net.consensys.cava.units
 
 Classes and utilities for working with 256 bit integers and Ethereum units.
 
-These classes are included in the standard Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-units` (`cava-units.jar`).
+These classes are included in the complete Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-units` (`cava-units.jar`).
 
 # Package net.consensys.cava.units.bigints
 

--- a/build.gradle
+++ b/build.gradle
@@ -190,8 +190,10 @@ allprojects {
     publishing {
       publications {
         MavenDeployment(MavenPublication) { publication ->
-          from components.java
-          artifact sourcesJar { classifier 'sources' }
+          if (project != rootProject) {
+            from components.java
+            artifact sourcesJar { classifier 'sources' }
+          }
           artifact dokkaJar { classifier 'javadoc' }
           groupId 'net.consensys.cava'
           artifactId project.jar.baseName
@@ -352,49 +354,36 @@ subprojects {
   task allDependencies(type: DependencyReportTask) {}
 }
 
+
 //////
-// Bundle all subprojects
-
-subprojects.each { evaluationDependsOn(it.path) }
-
-jar {
-  baseName = rootProject.name
-  manifest {
-    attributes('Implementation-Title': baseName,
-    'Implementation-Version': project.version)
-  }
-  subprojects.each {
-    from it.sourceSets.main.output
-    dependsOn it.classes
-  }
-}
+// Create a virtual package that depends on all components
 
 dependencies {
-  subprojects.each {
-    it.configurations.compile.allDependencies.each { d ->
-      if (d instanceof ExternalModuleDependency) {
-        add('compile', d)
-      }
-    }
-    it.configurations.runtime.allDependencies.each { d ->
-      if (d instanceof ExternalModuleDependency) {
-        add('runtime', d)
-      }
+  subprojects.each { p ->
+    switch (p.name) {
+      case 'eth-reference-tests':
+      // ignore
+        break
+      case 'crypto':
+        compile(p) {
+          exclude group: 'com.github.jnr', module: 'jnr-ffi'
+        }
+        break
+      case 'kv':
+      case 'merkle-trie':
+        compile(p) {
+          exclude group: 'org.jetbrains.kotlinx', module: 'kotlinx-coroutines-core'
+        }
+        break
+      default:
+        compile p
+        break
     }
   }
 }
 
-sourcesJar {
-  baseName = rootProject.name
-  manifest {
-    attributes('Implementation-Title': baseName,
-    'Implementation-Version': project.version)
-  }
-  subprojects.each {
-    from it.sourceSets.main.allSource
-    dependsOn it.classes
-  }
-}
+
+jar { enabled = false }
 
 javadoc {
   subprojects.each {

--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -7,11 +7,10 @@ dependencies {
   compile project(':io')
   compile project(':units')
   compile 'com.google.guava:guava'
-  compileOnly 'com.github.jnr:jnr-ffi'
+  compile 'com.github.jnr:jnr-ffi'
   compileOnly 'org.bouncycastle:bcprov-jdk15on'
 
   testCompile project(':junit')
-  testCompile 'com.github.jnr:jnr-ffi'
   testCompile 'org.bouncycastle:bcprov-jdk15on'
   testCompile 'org.junit.jupiter:junit-jupiter-api'
   testCompile 'org.junit.jupiter:junit-jupiter-params'

--- a/dependency-versions.gradle
+++ b/dependency-versions.gradle
@@ -9,6 +9,7 @@ dependencyManagement {
     dependency('io.vertx:vertx-core:3.5.3')
     dependency('com.google.code.findbugs:jsr305:3.0.2')
     dependency('org.antlr:antlr4:4.7.1')
+    dependency('org.antlr:antlr4-runtime:4.7.1')
     dependency('org.assertj:assertj-core:3.10.0')
     dependency('org.bouncycastle:bcpkix-jdk15on:1.60')
     dependency('org.bouncycastle:bcprov-jdk15on:1.60')

--- a/io/build.gradle
+++ b/io/build.gradle
@@ -1,8 +1,8 @@
 description = 'Classes and utilities for handling file and network IO.'
 
 dependencies {
-  compileOnly project(':units')
   compile 'com.google.guava:guava'
+  compileOnly project(':bytes')
 
   testCompile project(':bytes')
   testCompile project(':junit')

--- a/kv/build.gradle
+++ b/kv/build.gradle
@@ -2,9 +2,8 @@ description = 'Key value store implementations.'
 
 dependencies {
   compile project(':bytes')
-  compileOnly project(':concurrent')
   compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core'
-
+  compileOnly project(':concurrent')
   compileOnly 'io.lettuce:lettuce-core'
   compileOnly 'org.fusesource.leveldbjni:leveldbjni-all'
   compileOnly 'org.mapdb:mapdb'

--- a/toml/build.gradle
+++ b/toml/build.gradle
@@ -10,9 +10,16 @@ generateGrammarSource {
 
 javadoc { exclude '**/internal/**' }
 
+configurations {
+  compile {
+    extendsFrom = extendsFrom.findAll { it != configurations.antlr }
+  }
+}
+
 dependencies {
   antlr 'org.antlr:antlr4'
 
+  compile 'org.antlr:antlr4-runtime'
   compile 'com.google.code.findbugs:jsr305'
 
   testCompile 'org.junit.jupiter:junit-jupiter-api'


### PR DESCRIPTION
Rather than creating an uber-jar, this changes the cava.jar to only be a pom-only source of dependency information for including all the jars for each cava component. The uber-javadoc jar is still published.

Doing so resolves a potential dependency conflict situation, where a library depends on a single cava component, and a project includes both that library and the cava uber-jar.

The PR also adjusts dependencies to ensure necessary libraries are automatically included when using a single cava component. Larger dependencies are excluded from the dependency tree when using the complete cava distrubtion and must still be added explicitly.