### PR TITLE
Separate merkle-trie coroutine methods into experimental

### DIFF
--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -110,15 +110,11 @@ Implementations of the Ethereum Patricia Trie, as described at https://github.co
 
 These classes are included in the complete Cava distribution, or separately when using the gradle dependency `net.consensys.cava:cava-merkle-trie` (`cava-merkle-trie.jar`).
 
-Classes in this package depend upon the kotlinx-coroutines library, which is not automatically included when using the complete Cava distrubution. See https://github.com/Kotlin/kotlinx.coroutines. kotlinx-coroutines can be included using the gradle dependency `com.jetbrains.kotlinx:koltinx-coroutines-core`.
-
 # Package net.consensys.cava.trie.experimental
 
 Merkle Trie implementations using Kotlin coroutines.
 
 Note that these APIs are ready for production usage. The 'experimental' package name reflects the experimental nature of the coroutines design in Kotlin, as described at https://kotlinlang.org/docs/reference/coroutines.html#experimental-status-of-coroutines.
-
-Classes in this package depend upon the kotlinx-coroutines library, which is not automatically included when using the complete Cava distrubution. See https://github.com/Kotlin/kotlinx.coroutines. kotlinx-coroutines can be included using the gradle dependency `com.jetbrains.kotlinx:koltinx-coroutines-core`.
 
 # Package net.consensys.cava.units
 

--- a/merkle-trie/src/main/java/net/consensys/cava/trie/MerklePatriciaTrie.java
+++ b/merkle-trie/src/main/java/net/consensys/cava/trie/MerklePatriciaTrie.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.trie;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import net.consensys.cava.bytes.Bytes;
+
+import java.util.function.Function;
+
+/**
+ * An in-memory {@link MerkleTrie}.
+ */
+public interface MerklePatriciaTrie<V> extends MerkleTrie<Bytes, V> {
+
+  /**
+   * Create a trie.
+   *
+   * @param valueSerializer A function for serializing values to bytes.
+   * @return A new merkle trie.
+   */
+  static <V> MerklePatriciaTrie<V> create(Function<V, Bytes> valueSerializer) {
+    return new net.consensys.cava.trie.experimental.MerklePatriciaTrie<>(valueSerializer);
+  }
+
+  /**
+   * Create a trie with value of type {@link Bytes}.
+   *
+   * @return A new merkle trie.
+   */
+  static MerklePatriciaTrie<Bytes> storingBytes() {
+    return create(bytes -> bytes);
+  }
+
+  /**
+   * Create a trie with value of type {@link String}.
+   * <p>
+   * Strings are stored in UTF-8 encoding.
+   *
+   * @return A new merkle trie.
+   */
+  static MerklePatriciaTrie<String> storingStrings() {
+    return create(s -> Bytes.wrap(s.getBytes(UTF_8)));
+  }
+}

--- a/merkle-trie/src/main/java/net/consensys/cava/trie/StoredMerklePatriciaTrie.java
+++ b/merkle-trie/src/main/java/net/consensys/cava/trie/StoredMerklePatriciaTrie.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.trie;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.bytes.Bytes32;
+
+import java.util.function.Function;
+
+public interface StoredMerklePatriciaTrie<V> extends MerkleTrie<Bytes, V> {
+
+  /**
+   * Create a trie.
+   *
+   * @param storage The storage to use for persistence.
+   * @param valueSerializer A function for serializing values to bytes.
+   * @param valueDeserializer A function for deserializing values from bytes.
+   * @return A new merkle trie.
+   */
+  static <V> StoredMerklePatriciaTrie<V> create(
+      MerkleStorage storage,
+      Function<V, Bytes> valueSerializer,
+      Function<Bytes, V> valueDeserializer) {
+    return new net.consensys.cava.trie.experimental.StoredMerklePatriciaTrie<>(
+        new CoroutineMerkleStorageAdapter(storage),
+        valueSerializer,
+        valueDeserializer);
+  }
+
+  /**
+   * Create a trie.
+   *
+   * @param storage The storage to use for persistence.
+   * @param rootHash The initial root has for the trie, which should be already present in <tt>storage</tt>.
+   * @param valueSerializer A function for serializing values to bytes.
+   * @param valueDeserializer A function for deserializing values from bytes.
+   * @return A new merkle trie.
+   */
+  static <V> StoredMerklePatriciaTrie<V> create(
+      MerkleStorage storage,
+      Bytes32 rootHash,
+      Function<V, Bytes> valueSerializer,
+      Function<Bytes, V> valueDeserializer) {
+    return new net.consensys.cava.trie.experimental.StoredMerklePatriciaTrie<>(
+        new CoroutineMerkleStorageAdapter(storage),
+        rootHash,
+        valueSerializer,
+        valueDeserializer);
+  }
+
+  /**
+   * Create a trie with value of type {@link Bytes}.
+   *
+   * @param storage The storage to use for persistence.
+   * @return A new merkle trie.
+   */
+  static StoredMerklePatriciaTrie<Bytes> storingBytes(MerkleStorage storage) {
+    return create(storage, bytes -> bytes, bytes -> bytes);
+  }
+
+  /**
+   * Create a trie with value of type {@link Bytes}.
+   *
+   * @param storage The storage to use for persistence.
+   * @param rootHash The initial root has for the trie, which should be already present in `storage`.
+   * @return A new merkle trie.
+   */
+  static StoredMerklePatriciaTrie<Bytes> storingBytes(MerkleStorage storage, Bytes32 rootHash) {
+    return create(storage, rootHash, bytes -> bytes, bytes -> bytes);
+  }
+
+  /**
+   * Create a trie with value of type {@link String}.
+   *
+   * Strings are stored in UTF-8 encoding.
+   *
+   * @param storage The storage to use for persistence.
+   * @return A new merkle trie.
+   */
+  static StoredMerklePatriciaTrie<String> storingStrings(MerkleStorage storage) {
+    return create(storage, s -> Bytes.wrap(s.getBytes(UTF_8)), bytes -> new String(bytes.toArrayUnsafe(), UTF_8));
+  }
+
+  /**
+   * Create a trie with value of type {@link String}.
+   *
+   * Strings are stored in UTF-8 encoding.
+   *
+   * @param storage The storage to use for persistence.
+   * @param rootHash The initial root has for the trie, which should be already present in `storage`.
+   * @return A new merkle trie.
+   */
+  static StoredMerklePatriciaTrie<String> storingStrings(MerkleStorage storage, Bytes32 rootHash) {
+    return create(
+        storage,
+        rootHash,
+        s -> Bytes.wrap(s.getBytes(UTF_8)),
+        bytes -> new String(bytes.toArrayUnsafe(), UTF_8));
+  }
+
+  /**
+   * Forces any cached trie nodes to be released, so they can be garbage collected.
+   * <p>
+   * Note: nodes are already stored using {@link java.lang.ref.SoftReference}'s, so they will be released automatically
+   * based on memory demands.
+   */
+  void clearCache();
+}

--- a/merkle-trie/src/main/kotlin/net/consensys/cava/trie/MerkleTrie.kt
+++ b/merkle-trie/src/main/kotlin/net/consensys/cava/trie/MerkleTrie.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.trie
+
+import net.consensys.cava.bytes.Bytes
+import net.consensys.cava.bytes.Bytes32
+import net.consensys.cava.concurrent.AsyncCompletion
+import net.consensys.cava.concurrent.AsyncResult
+import net.consensys.cava.crypto.Hash
+import net.consensys.cava.rlp.RLP
+
+/**
+ * A Merkle Trie.
+ */
+interface MerkleTrie<in K, V> {
+  companion object {
+    /**
+     * The root hash of an empty tree.
+     */
+    val EMPTY_TRIE_ROOT_HASH: Bytes32 = Hash.keccak256(RLP.encodeValue(Bytes.EMPTY))
+  }
+
+  /**
+   * Returns the value that corresponds to the specified key, or an empty byte array if no such value exists.
+   *
+   * @param key The key of the value to be returned.
+   * @return An Optional containing the value that corresponds to the specified key, or an empty Optional if no such
+   * value exists.
+   */
+  fun getAsync(key: K): AsyncResult<V?>
+
+  /**
+   * Updates the value that corresponds to the specified key, creating the value if one does not already exist.
+   *
+   * If the value is null, deletes the value that corresponds to the specified key, if such a value exists.
+   *
+   * @param key The key that corresponds to the value to be updated.
+   * @param value The value to associate the key with.
+   * @return A completion that will complete when the value has been put into the trie.
+   */
+  fun putAsync(key: K, value: V?): AsyncCompletion
+
+  /**
+   * Deletes the value that corresponds to the specified key, if such a value exists.
+   *
+   * @param key The key of the value to be deleted.
+   * @return A completion that will complete when the value has been removed.
+   */
+  fun removeAsync(key: K): AsyncCompletion
+
+  /**
+   * Returns the KECCAK256 hash of the root node of the trie.
+   *
+   * @return The KECCAK256 hash of the root node of the trie.
+   */
+  fun rootHash(): Bytes32
+}

--- a/merkle-trie/src/main/kotlin/net/consensys/cava/trie/experimental/MerklePatriciaTrie.kt
+++ b/merkle-trie/src/main/kotlin/net/consensys/cava/trie/experimental/MerklePatriciaTrie.kt
@@ -29,7 +29,9 @@ internal fun stringDeserializer(b: Bytes): String = String(b.toArrayUnsafe(), UT
  * @param valueSerializer A function for serializing values to bytes.
  * @constructor Creates an empty trie.
  */
-class MerklePatriciaTrie<V>(valueSerializer: (V) -> Bytes) : MerkleTrie<Bytes, V> {
+class MerklePatriciaTrie<V>(
+  valueSerializer: (V) -> Bytes
+) : MerkleTrie<Bytes, V>, net.consensys.cava.trie.MerklePatriciaTrie<V> {
 
   companion object {
     /**

--- a/merkle-trie/src/main/kotlin/net/consensys/cava/trie/experimental/MerkleTrie.kt
+++ b/merkle-trie/src/main/kotlin/net/consensys/cava/trie/experimental/MerkleTrie.kt
@@ -12,27 +12,15 @@
  */
 package net.consensys.cava.trie.experimental
 
-import net.consensys.cava.bytes.Bytes
-import net.consensys.cava.bytes.Bytes32
 import net.consensys.cava.concurrent.AsyncCompletion
 import net.consensys.cava.concurrent.AsyncResult
 import net.consensys.cava.concurrent.coroutines.experimental.asyncCompletion
 import net.consensys.cava.concurrent.coroutines.experimental.asyncResult
-import net.consensys.cava.crypto.Hash.keccak256
-import net.consensys.cava.rlp.RLP
-import java.util.Optional
 
 /**
  * A Merkle Trie.
  */
-interface MerkleTrie<in K, V> {
-
-  companion object {
-    /**
-     * The root hash of an empty tree.
-     */
-    val EMPTY_TRIE_ROOT_HASH: Bytes32 = keccak256(RLP.encodeValue(Bytes.EMPTY))
-  }
+interface MerkleTrie<in K, V> : net.consensys.cava.trie.MerkleTrie<K, V> {
 
   /**
    * Returns the value that corresponds to the specified key, or an empty byte array if no such value exists.
@@ -50,7 +38,7 @@ interface MerkleTrie<in K, V> {
    * @return An Optional containing the value that corresponds to the specified key, or an empty Optional if no such
    * value exists.
    */
-  fun getAsync(key: K): AsyncResult<Optional<V>> = asyncResult { Optional.ofNullable(get(key)) }
+  override fun getAsync(key: K): AsyncResult<V?> = asyncResult { get(key) }
 
   /**
    * Updates the value that corresponds to the specified key, creating the value if one does not already exist.
@@ -72,7 +60,7 @@ interface MerkleTrie<in K, V> {
    * @param value The value to associate the key with.
    * @return A completion that will complete when the value has been put into the trie.
    */
-  fun putAsync(key: K, value: V?): AsyncCompletion = asyncCompletion { put(key, value) }
+  override fun putAsync(key: K, value: V?): AsyncCompletion = asyncCompletion { put(key, value) }
 
   /**
    * Deletes the value that corresponds to the specified key, if such a value exists.
@@ -88,12 +76,5 @@ interface MerkleTrie<in K, V> {
    * @param key The key of the value to be deleted.
    * @return A completion that will complete when the value has been removed.
    */
-  fun removeAsync(key: K): AsyncCompletion = asyncCompletion { remove(key) }
-
-  /**
-   * Returns the KECCAK256 hash of the root node of the trie.
-   *
-   * @return The KECCAK256 hash of the root node of the trie.
-   */
-  fun rootHash(): Bytes32
+  override fun removeAsync(key: K): AsyncCompletion = asyncCompletion { remove(key) }
 }

--- a/merkle-trie/src/main/kotlin/net/consensys/cava/trie/experimental/StoredMerklePatriciaTrie.kt
+++ b/merkle-trie/src/main/kotlin/net/consensys/cava/trie/experimental/StoredMerklePatriciaTrie.kt
@@ -15,6 +15,7 @@ package net.consensys.cava.trie.experimental
 import net.consensys.cava.bytes.Bytes
 import net.consensys.cava.bytes.Bytes32
 import net.consensys.cava.trie.CompactEncoding.bytesToPath
+import net.consensys.cava.trie.MerkleTrie.Companion.EMPTY_TRIE_ROOT_HASH
 import java.util.function.Function
 
 /**
@@ -22,7 +23,7 @@ import java.util.function.Function
  *
  * @param <V> The type of values stored by this trie.
  */
-class StoredMerklePatriciaTrie<V> : MerkleTrie<Bytes, V> {
+class StoredMerklePatriciaTrie<V> : MerkleTrie<Bytes, V>, net.consensys.cava.trie.StoredMerklePatriciaTrie<V> {
 
   companion object {
     /**
@@ -85,7 +86,7 @@ class StoredMerklePatriciaTrie<V> : MerkleTrie<Bytes, V> {
     storage: MerkleStorage,
     valueSerializer: Function<V, Bytes>,
     valueDeserializer: Function<Bytes, V>
-  ) : this(storage, MerkleTrie.EMPTY_TRIE_ROOT_HASH, valueSerializer::apply, valueDeserializer::apply)
+  ) : this(storage, EMPTY_TRIE_ROOT_HASH, valueSerializer::apply, valueDeserializer::apply)
 
   /**
    * Create a trie.
@@ -98,7 +99,7 @@ class StoredMerklePatriciaTrie<V> : MerkleTrie<Bytes, V> {
     storage: MerkleStorage,
     valueSerializer: (V) -> Bytes,
     valueDeserializer: (Bytes) -> V
-  ) : this(storage, MerkleTrie.EMPTY_TRIE_ROOT_HASH, valueSerializer, valueDeserializer)
+  ) : this(storage, EMPTY_TRIE_ROOT_HASH, valueSerializer, valueDeserializer)
 
   /**
    * Create a trie.
@@ -132,7 +133,7 @@ class StoredMerklePatriciaTrie<V> : MerkleTrie<Bytes, V> {
     this.storage = storage
     this.nodeFactory = StoredNodeFactory(storage, valueSerializer, valueDeserializer)
 
-    this.root = if (rootHash == MerkleTrie.EMPTY_TRIE_ROOT_HASH) {
+    this.root = if (rootHash == EMPTY_TRIE_ROOT_HASH) {
       NullNode.instance()
     } else {
       StoredNode(nodeFactory, rootHash)
@@ -158,7 +159,7 @@ class StoredMerklePatriciaTrie<V> : MerkleTrie<Bytes, V> {
    * Note: nodes are already stored using [java.lang.ref.SoftReference]'s, so they will be released automatically
    * based on memory demands.
    */
-  fun clearCache() {
+  override fun clearCache() {
     val currentRoot = root
     if (currentRoot is StoredNode<*>) {
       currentRoot.unload()

--- a/merkle-trie/src/test/java/net/consensys/cava/trie/MerklePatriciaTrieJavaTest.java
+++ b/merkle-trie/src/test/java/net/consensys/cava/trie/MerklePatriciaTrieJavaTest.java
@@ -10,53 +10,32 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package net.consensys.cava.trie.experimental;
+package net.consensys.cava.trie;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.concurrent.AsyncCompletion;
-import net.consensys.cava.concurrent.AsyncResult;
 import net.consensys.cava.junit.BouncyCastleExtension;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(BouncyCastleExtension.class)
-class StoredMerklePatriciaTrieJavaTest {
-
-  private MerkleStorage merkleStorage;
-  private StoredMerklePatriciaTrie<String> trie;
+class MerklePatriciaTrieJavaTest {
+  private MerkleTrie<Bytes, String> trie;
 
   @BeforeEach
   void setup() {
-    Map<Bytes32, Bytes> storage = new HashMap<>();
-    merkleStorage = new AsyncMerkleStorage() {
-      @Override
-      public @NotNull AsyncResult<Optional<Bytes>> getAsync(@NotNull Bytes32 hash) {
-        return AsyncResult.completed(Optional.ofNullable(storage.get(hash)));
-      }
-
-      @Override
-      public @NotNull AsyncCompletion putAsync(@NotNull Bytes32 hash, @NotNull Bytes content) {
-        storage.put(hash, content);
-        return AsyncCompletion.completed();
-      }
-    };
-
-    trie = StoredMerklePatriciaTrie.storingStrings(merkleStorage);
+    trie = MerklePatriciaTrie.storingStrings();
   }
 
   @Test
   void testEmptyTreeReturnsEmpty() throws Exception {
-    assertFalse(trie.getAsync(Bytes.EMPTY).get().isPresent());
+    assertNull(trie.getAsync(Bytes.EMPTY).get());
   }
 
   @Test
@@ -70,7 +49,7 @@ class StoredMerklePatriciaTrieJavaTest {
 
     trie.putAsync(key, "value1").join();
     trie.putAsync(key, null).join();
-    assertFalse(trie.getAsync(key).get().isPresent());
+    assertNull(trie.getAsync(key).get());
   }
 
   @Test
@@ -78,10 +57,10 @@ class StoredMerklePatriciaTrieJavaTest {
     final Bytes key = Bytes.of(1);
 
     trie.putAsync(key, "value1").join();
-    assertEquals(Optional.of("value1"), trie.getAsync(key).get());
+    assertEquals("value1", trie.getAsync(key).get());
 
     trie.putAsync(key, "value2").join();
-    assertEquals(Optional.of("value2"), trie.getAsync(key).get());
+    assertEquals("value2", trie.getAsync(key).get());
   }
 
   @Test
@@ -105,7 +84,7 @@ class StoredMerklePatriciaTrieJavaTest {
     final Bytes key1 = Bytes.of(1);
     final Bytes key2 = Bytes.of(1, 3);
     trie.putAsync(key1, "value").join();
-    assertFalse(trie.getAsync(key2).get().isPresent());
+    assertNull(trie.getAsync(key2).get());
   }
 
   @Test
@@ -115,8 +94,8 @@ class StoredMerklePatriciaTrieJavaTest {
 
     trie.putAsync(key1, "value1").join();
     trie.putAsync(key2, "value2").join();
-    assertEquals(Optional.of("value1"), trie.getAsync(key1).get());
-    assertEquals(Optional.of("value2"), trie.getAsync(key2).get());
+    assertEquals("value1", trie.getAsync(key1).get());
+    assertEquals("value2", trie.getAsync(key2).get());
   }
 
   @Test
@@ -127,7 +106,7 @@ class StoredMerklePatriciaTrieJavaTest {
 
     trie.putAsync(key1, "value1").join();
     trie.putAsync(key2, "value2").join();
-    assertFalse(trie.getAsync(key3).get().isPresent());
+    assertNull(trie.getAsync(key3).get());
   }
 
   @Test
@@ -137,8 +116,8 @@ class StoredMerklePatriciaTrieJavaTest {
 
     trie.putAsync(key1, "value1").join();
     trie.putAsync(key2, "value2").join();
-    assertEquals(Optional.of("value1"), trie.getAsync(key1).get());
-    assertEquals(Optional.of("value2"), trie.getAsync(key2).get());
+    assertEquals("value1", trie.getAsync(key1).get());
+    assertEquals("value2", trie.getAsync(key2).get());
   }
 
   @Test
@@ -148,9 +127,9 @@ class StoredMerklePatriciaTrieJavaTest {
 
     trie.putAsync(key1, "value1").join();
     trie.putAsync(key2, "value2").join();
-    assertEquals(Optional.of("value1"), trie.getAsync(key1).get());
-    assertEquals(Optional.of("value2"), trie.getAsync(key2).get());
-    assertFalse(trie.getAsync(Bytes.of(1, 4)).get().isPresent());
+    assertEquals("value1", trie.getAsync(key1).get());
+    assertEquals("value2", trie.getAsync(key2).get());
+    assertNull(trie.getAsync(Bytes.of(1, 4)).get());
   }
 
   @Test
@@ -162,12 +141,12 @@ class StoredMerklePatriciaTrieJavaTest {
     trie.putAsync(key1, "value1").join();
     trie.putAsync(key2, "value2").join();
     trie.putAsync(key3, "value3").join();
-    assertEquals(Optional.of("value1"), trie.getAsync(key1).get());
-    assertEquals(Optional.of("value2"), trie.getAsync(key2).get());
-    assertEquals(Optional.of("value3"), trie.getAsync(key3).get());
-    assertFalse(trie.getAsync(Bytes.of(1, 4)).get().isPresent());
-    assertFalse(trie.getAsync(Bytes.of(2, 4)).get().isPresent());
-    assertFalse(trie.getAsync(Bytes.of(3)).get().isPresent());
+    assertEquals("value1", trie.getAsync(key1).get());
+    assertEquals("value2", trie.getAsync(key2).get());
+    assertEquals("value3", trie.getAsync(key3).get());
+    assertNull(trie.getAsync(Bytes.of(1, 4)).get());
+    assertNull(trie.getAsync(Bytes.of(2, 4)).get());
+    assertNull(trie.getAsync(Bytes.of(3)).get());
   }
 
   @Test
@@ -179,9 +158,9 @@ class StoredMerklePatriciaTrieJavaTest {
     trie.putAsync(key1, "value1").join();
     trie.putAsync(key2, "value2").join();
     trie.putAsync(key3, "value3").join();
-    assertEquals(Optional.of("value1"), trie.getAsync(key1).get());
-    assertEquals(Optional.of("value2"), trie.getAsync(key2).get());
-    assertEquals(Optional.of("value3"), trie.getAsync(key3).get());
+    assertEquals("value1", trie.getAsync(key1).get());
+    assertEquals("value2", trie.getAsync(key2).get());
+    assertEquals("value3", trie.getAsync(key3).get());
   }
 
   @Test
@@ -191,12 +170,12 @@ class StoredMerklePatriciaTrieJavaTest {
 
     trie.putAsync(key1, "value1").join();
     trie.putAsync(key2, "value2").join();
-    assertEquals(Optional.of("value1"), trie.getAsync(key1).get());
-    assertEquals(Optional.of("value2"), trie.getAsync(key2).get());
+    assertEquals("value1", trie.getAsync(key1).get());
+    assertEquals("value2", trie.getAsync(key2).get());
 
     trie.putAsync(key1, "value3").join();
-    assertEquals(Optional.of("value3"), trie.getAsync(key1).get());
-    assertEquals(Optional.of("value2"), trie.getAsync(key2).get());
+    assertEquals("value3", trie.getAsync(key1).get());
+    assertEquals("value2", trie.getAsync(key2).get());
   }
 
   @Test
@@ -216,11 +195,11 @@ class StoredMerklePatriciaTrieJavaTest {
     trie.removeAsync(key2).join();
     trie.removeAsync(key3).join();
 
-    assertEquals(Optional.of("value1"), trie.getAsync(key1).get());
-    assertFalse(trie.getAsync(key2).get().isPresent());
-    assertFalse(trie.getAsync(key3).get().isPresent());
-    assertEquals(Optional.of("value4"), trie.getAsync(key4).get());
-    assertEquals(Optional.of("value5"), trie.getAsync(key5).get());
+    assertEquals("value1", trie.getAsync(key1).get());
+    assertNull(trie.getAsync(key2).get());
+    assertNull(trie.getAsync(key3).get());
+    assertEquals("value4", trie.getAsync(key4).get());
+    assertEquals("value5", trie.getAsync(key5).get());
   }
 
   @Test
@@ -257,50 +236,11 @@ class StoredMerklePatriciaTrieJavaTest {
     assertNotEquals(hash3, hash1);
     assertNotEquals(hash3, hash2);
 
-    trie.clearCache();
-
     trie.putAsync(key1, "value1").join();
     assertEquals(hash2, trie.rootHash());
 
     trie.removeAsync(key2).join();
     trie.removeAsync(key3).join();
     assertEquals(hash1, trie.rootHash());
-  }
-
-  @Test
-  void testCanReloadTrieFromHash() throws Exception {
-    final Bytes key1 = Bytes.of(1, 5, 8, 9);
-    final Bytes key2 = Bytes.of(1, 6, 1, 2);
-    final Bytes key3 = Bytes.of(1, 6, 1, 3);
-
-    trie.putAsync(key1, "value1").join();
-    final Bytes32 hash1 = trie.rootHash();
-
-    trie.putAsync(key2, "value2").join();
-    trie.putAsync(key3, "value3").join();
-    final Bytes32 hash2 = trie.rootHash();
-    assertNotEquals(hash2, hash1);
-
-    trie.putAsync(key1, "value4").join();
-    final Bytes32 hash3 = trie.rootHash();
-    assertNotEquals(hash3, hash1);
-    assertNotEquals(hash3, hash2);
-
-    assertEquals(Optional.of("value4"), trie.getAsync(key1).get());
-
-    trie = StoredMerklePatriciaTrie.storingStrings(merkleStorage, hash1);
-    assertEquals(Optional.of("value1"), trie.getAsync(key1).get());
-    assertEquals(Optional.empty(), trie.getAsync(key2).get());
-    assertEquals(Optional.empty(), trie.getAsync(key3).get());
-
-    trie = StoredMerklePatriciaTrie.storingStrings(merkleStorage, hash2);
-    assertEquals(Optional.of("value1"), trie.getAsync(key1).get());
-    assertEquals(Optional.of("value2"), trie.getAsync(key2).get());
-    assertEquals(Optional.of("value3"), trie.getAsync(key3).get());
-
-    trie = StoredMerklePatriciaTrie.storingStrings(merkleStorage, hash3);
-    assertEquals(Optional.of("value4"), trie.getAsync(key1).get());
-    assertEquals(Optional.of("value2"), trie.getAsync(key2).get());
-    assertEquals(Optional.of("value3"), trie.getAsync(key3).get());
   }
 }

--- a/merkle-trie/src/test/java/net/consensys/cava/trie/StoredMerklePatriciaTrieJavaTest.java
+++ b/merkle-trie/src/test/java/net/consensys/cava/trie/StoredMerklePatriciaTrieJavaTest.java
@@ -10,34 +10,52 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package net.consensys.cava.trie.experimental;
+package net.consensys.cava.trie;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
+import net.consensys.cava.concurrent.AsyncCompletion;
+import net.consensys.cava.concurrent.AsyncResult;
 import net.consensys.cava.junit.BouncyCastleExtension;
 
-import java.util.Optional;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(BouncyCastleExtension.class)
-class MerklePatriciaTrieJavaTest {
-  private MerkleTrie<Bytes, String> trie;
+class StoredMerklePatriciaTrieJavaTest {
+
+  private MerkleStorage merkleStorage;
+  private StoredMerklePatriciaTrie<String> trie;
 
   @BeforeEach
   void setup() {
-    trie = MerklePatriciaTrie.storingStrings();
+    Map<Bytes32, Bytes> storage = new HashMap<>();
+    merkleStorage = new MerkleStorage() {
+      @Override
+      public @NotNull AsyncResult<Bytes> getAsync(@NotNull Bytes32 hash) {
+        return AsyncResult.completed(storage.get(hash));
+      }
+
+      @Override
+      public @NotNull AsyncCompletion putAsync(@NotNull Bytes32 hash, @NotNull Bytes content) {
+        storage.put(hash, content);
+        return AsyncCompletion.completed();
+      }
+    };
+
+    trie = StoredMerklePatriciaTrie.storingStrings(merkleStorage);
   }
 
   @Test
   void testEmptyTreeReturnsEmpty() throws Exception {
-    assertFalse(trie.getAsync(Bytes.EMPTY).get().isPresent());
+    assertNull(trie.getAsync(Bytes.EMPTY).get());
   }
 
   @Test
@@ -51,7 +69,7 @@ class MerklePatriciaTrieJavaTest {
 
     trie.putAsync(key, "value1").join();
     trie.putAsync(key, null).join();
-    assertFalse(trie.getAsync(key).get().isPresent());
+    assertNull(trie.getAsync(key).get());
   }
 
   @Test
@@ -59,10 +77,10 @@ class MerklePatriciaTrieJavaTest {
     final Bytes key = Bytes.of(1);
 
     trie.putAsync(key, "value1").join();
-    assertEquals(Optional.of("value1"), trie.getAsync(key).get());
+    assertEquals("value1", trie.getAsync(key).get());
 
     trie.putAsync(key, "value2").join();
-    assertEquals(Optional.of("value2"), trie.getAsync(key).get());
+    assertEquals("value2", trie.getAsync(key).get());
   }
 
   @Test
@@ -86,7 +104,7 @@ class MerklePatriciaTrieJavaTest {
     final Bytes key1 = Bytes.of(1);
     final Bytes key2 = Bytes.of(1, 3);
     trie.putAsync(key1, "value").join();
-    assertFalse(trie.getAsync(key2).get().isPresent());
+    assertNull(trie.getAsync(key2).get());
   }
 
   @Test
@@ -96,8 +114,8 @@ class MerklePatriciaTrieJavaTest {
 
     trie.putAsync(key1, "value1").join();
     trie.putAsync(key2, "value2").join();
-    assertEquals(Optional.of("value1"), trie.getAsync(key1).get());
-    assertEquals(Optional.of("value2"), trie.getAsync(key2).get());
+    assertEquals("value1", trie.getAsync(key1).get());
+    assertEquals("value2", trie.getAsync(key2).get());
   }
 
   @Test
@@ -108,7 +126,7 @@ class MerklePatriciaTrieJavaTest {
 
     trie.putAsync(key1, "value1").join();
     trie.putAsync(key2, "value2").join();
-    assertFalse(trie.getAsync(key3).get().isPresent());
+    assertNull(trie.getAsync(key3).get());
   }
 
   @Test
@@ -118,8 +136,8 @@ class MerklePatriciaTrieJavaTest {
 
     trie.putAsync(key1, "value1").join();
     trie.putAsync(key2, "value2").join();
-    assertEquals(Optional.of("value1"), trie.getAsync(key1).get());
-    assertEquals(Optional.of("value2"), trie.getAsync(key2).get());
+    assertEquals("value1", trie.getAsync(key1).get());
+    assertEquals("value2", trie.getAsync(key2).get());
   }
 
   @Test
@@ -129,9 +147,9 @@ class MerklePatriciaTrieJavaTest {
 
     trie.putAsync(key1, "value1").join();
     trie.putAsync(key2, "value2").join();
-    assertEquals(Optional.of("value1"), trie.getAsync(key1).get());
-    assertEquals(Optional.of("value2"), trie.getAsync(key2).get());
-    assertFalse(trie.getAsync(Bytes.of(1, 4)).get().isPresent());
+    assertEquals("value1", trie.getAsync(key1).get());
+    assertEquals("value2", trie.getAsync(key2).get());
+    assertNull(trie.getAsync(Bytes.of(1, 4)).get());
   }
 
   @Test
@@ -143,12 +161,12 @@ class MerklePatriciaTrieJavaTest {
     trie.putAsync(key1, "value1").join();
     trie.putAsync(key2, "value2").join();
     trie.putAsync(key3, "value3").join();
-    assertEquals(Optional.of("value1"), trie.getAsync(key1).get());
-    assertEquals(Optional.of("value2"), trie.getAsync(key2).get());
-    assertEquals(Optional.of("value3"), trie.getAsync(key3).get());
-    assertFalse(trie.getAsync(Bytes.of(1, 4)).get().isPresent());
-    assertFalse(trie.getAsync(Bytes.of(2, 4)).get().isPresent());
-    assertFalse(trie.getAsync(Bytes.of(3)).get().isPresent());
+    assertEquals("value1", trie.getAsync(key1).get());
+    assertEquals("value2", trie.getAsync(key2).get());
+    assertEquals("value3", trie.getAsync(key3).get());
+    assertNull(trie.getAsync(Bytes.of(1, 4)).get());
+    assertNull(trie.getAsync(Bytes.of(2, 4)).get());
+    assertNull(trie.getAsync(Bytes.of(3)).get());
   }
 
   @Test
@@ -160,9 +178,9 @@ class MerklePatriciaTrieJavaTest {
     trie.putAsync(key1, "value1").join();
     trie.putAsync(key2, "value2").join();
     trie.putAsync(key3, "value3").join();
-    assertEquals(Optional.of("value1"), trie.getAsync(key1).get());
-    assertEquals(Optional.of("value2"), trie.getAsync(key2).get());
-    assertEquals(Optional.of("value3"), trie.getAsync(key3).get());
+    assertEquals("value1", trie.getAsync(key1).get());
+    assertEquals("value2", trie.getAsync(key2).get());
+    assertEquals("value3", trie.getAsync(key3).get());
   }
 
   @Test
@@ -172,12 +190,12 @@ class MerklePatriciaTrieJavaTest {
 
     trie.putAsync(key1, "value1").join();
     trie.putAsync(key2, "value2").join();
-    assertEquals(Optional.of("value1"), trie.getAsync(key1).get());
-    assertEquals(Optional.of("value2"), trie.getAsync(key2).get());
+    assertEquals("value1", trie.getAsync(key1).get());
+    assertEquals("value2", trie.getAsync(key2).get());
 
     trie.putAsync(key1, "value3").join();
-    assertEquals(Optional.of("value3"), trie.getAsync(key1).get());
-    assertEquals(Optional.of("value2"), trie.getAsync(key2).get());
+    assertEquals("value3", trie.getAsync(key1).get());
+    assertEquals("value2", trie.getAsync(key2).get());
   }
 
   @Test
@@ -197,11 +215,11 @@ class MerklePatriciaTrieJavaTest {
     trie.removeAsync(key2).join();
     trie.removeAsync(key3).join();
 
-    assertEquals(Optional.of("value1"), trie.getAsync(key1).get());
-    assertFalse(trie.getAsync(key2).get().isPresent());
-    assertFalse(trie.getAsync(key3).get().isPresent());
-    assertEquals(Optional.of("value4"), trie.getAsync(key4).get());
-    assertEquals(Optional.of("value5"), trie.getAsync(key5).get());
+    assertEquals("value1", trie.getAsync(key1).get());
+    assertNull(trie.getAsync(key2).get());
+    assertNull(trie.getAsync(key3).get());
+    assertEquals("value4", trie.getAsync(key4).get());
+    assertEquals("value5", trie.getAsync(key5).get());
   }
 
   @Test
@@ -238,11 +256,50 @@ class MerklePatriciaTrieJavaTest {
     assertNotEquals(hash3, hash1);
     assertNotEquals(hash3, hash2);
 
+    trie.clearCache();
+
     trie.putAsync(key1, "value1").join();
     assertEquals(hash2, trie.rootHash());
 
     trie.removeAsync(key2).join();
     trie.removeAsync(key3).join();
     assertEquals(hash1, trie.rootHash());
+  }
+
+  @Test
+  void testCanReloadTrieFromHash() throws Exception {
+    final Bytes key1 = Bytes.of(1, 5, 8, 9);
+    final Bytes key2 = Bytes.of(1, 6, 1, 2);
+    final Bytes key3 = Bytes.of(1, 6, 1, 3);
+
+    trie.putAsync(key1, "value1").join();
+    final Bytes32 hash1 = trie.rootHash();
+
+    trie.putAsync(key2, "value2").join();
+    trie.putAsync(key3, "value3").join();
+    final Bytes32 hash2 = trie.rootHash();
+    assertNotEquals(hash2, hash1);
+
+    trie.putAsync(key1, "value4").join();
+    final Bytes32 hash3 = trie.rootHash();
+    assertNotEquals(hash3, hash1);
+    assertNotEquals(hash3, hash2);
+
+    assertEquals("value4", trie.getAsync(key1).get());
+
+    trie = StoredMerklePatriciaTrie.storingStrings(merkleStorage, hash1);
+    assertEquals("value1", trie.getAsync(key1).get());
+    assertNull(trie.getAsync(key2).get());
+    assertNull(trie.getAsync(key3).get());
+
+    trie = StoredMerklePatriciaTrie.storingStrings(merkleStorage, hash2);
+    assertEquals("value1", trie.getAsync(key1).get());
+    assertEquals("value2", trie.getAsync(key2).get());
+    assertEquals("value3", trie.getAsync(key3).get());
+
+    trie = StoredMerklePatriciaTrie.storingStrings(merkleStorage, hash3);
+    assertEquals("value4", trie.getAsync(key1).get());
+    assertEquals("value2", trie.getAsync(key2).get());
+    assertEquals("value3", trie.getAsync(key3).get());
   }
 }


### PR DESCRIPTION
Also changes the API to return null rather than Optional. So a breaking change.