### PR TITLE
Add CoroutineChannelGroup

### DIFF
--- a/net-coroutines/src/main/kotlin/net/consensys/cava/net/coroutines/experimental/CoroutineChannelGroup.kt
+++ b/net-coroutines/src/main/kotlin/net/consensys/cava/net/coroutines/experimental/CoroutineChannelGroup.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.net.coroutines.experimental
+
+import org.logl.LoggerProvider
+import java.nio.channels.Channel
+import java.nio.channels.SelectableChannel
+import java.nio.channels.ShutdownChannelGroupException
+import java.util.Collections
+import java.util.WeakHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import kotlin.coroutines.experimental.Continuation
+import kotlin.coroutines.experimental.suspendCoroutine
+
+/**
+ * A common co-routine channel group.
+ *
+ * This group is created with a selector per available processors.
+ */
+val CommonCoroutineGroup: CoroutineChannelGroup = CoroutineChannelGroup.open()
+
+/**
+ * A grouping of co-routine channels for the purpose of resource sharing.
+ *
+ * A co-routine channel group encapsulates the mechanics required to handle completion of suspended I/O operations
+ * initiated on channels bound to the group.
+ */
+sealed class CoroutineChannelGroup {
+
+  companion object {
+    /**
+     * Create a co-routine channel group.
+     *
+     * @param nSelectors The number of selectors that should be active in the group. Defaults to one per available
+     *         system processor.
+     * @param executor The thread pool for running selectors. Defaults to a fixed size thread pool, with one thread
+     *         per selector.
+     * @param loggerProvider A provider for logger instances.
+     * @param selectTimeout The maximum time the selection operation will wait before checking for closed channels.
+     * @param idleTimeout The minimum idle time before the selection loop of a selector exits.
+     * @return A co-routine channel group.
+     */
+    fun open(
+      nSelectors: Int = Runtime.getRuntime().availableProcessors(),
+      executor: Executor = Executors.newFixedThreadPool(nSelectors, CoroutineSelector.DEFAULT_THREAD_FACTORY),
+      loggerProvider: LoggerProvider = LoggerProvider.nullProvider(),
+      selectTimeout: Long = 1000,
+      idleTimeout: Long = 10000
+    ): CoroutineChannelGroup {
+      require(nSelectors > 0) { "nSelectors must be larger than zero" }
+      return CoroutineSelectorChannelGroup(nSelectors, executor, loggerProvider, selectTimeout, idleTimeout)
+    }
+  }
+
+  internal abstract fun register(channel: Channel): Boolean
+
+  internal abstract fun deRegister(channel: Channel): Boolean
+
+  internal abstract fun selectorFor(channel: SelectableChannel): CoroutineSelector
+
+  internal suspend fun select(channel: SelectableChannel, ops: Int) {
+    selectorFor(channel).select(channel, ops)
+  }
+
+  /**
+   * Check if the group has been shutdown.
+   *
+   * @return `true` if the group is shutdown.
+   */
+  abstract val isShutdown: Boolean
+
+  /**
+   * Check if the group has terminated.
+   *
+   * @return `true` if the group has terminated.
+   */
+  abstract val isTerminated: Boolean
+
+  /**
+   * Shuts down the group.
+   */
+  abstract fun shutdown()
+
+  /**
+   * Shuts down the group and closes all open channels in the group.
+   */
+  abstract fun shutdownNow()
+
+  /**
+   * Suspend until the group has terminated.
+   */
+  abstract suspend fun awaitTermination()
+}
+
+internal class CoroutineSelectorChannelGroup(
+  nSelectors: Int,
+  private val executor: Executor,
+  loggerProvider: LoggerProvider,
+  selectTimeout: Long,
+  idleTimeout: Long
+) : CoroutineChannelGroup() {
+
+  private val logger = loggerProvider.getLogger(CoroutineSelectorChannelGroup::class.java)
+
+  private var selectors: Array<CoroutineSelector>? = Array(nSelectors) {
+    CoroutineSelector.open(executor, loggerProvider, selectTimeout, idleTimeout)
+  }
+  private val channels = Collections.synchronizedSet(Collections.newSetFromMap(WeakHashMap<Channel, Boolean>()))
+  @Volatile
+  override var isShutdown: Boolean = false
+  @Volatile
+  private var wasTerminated: Boolean = false
+  private val pendingTermination = ConcurrentLinkedQueue<Continuation<Unit>>()
+
+  override fun register(channel: Channel): Boolean {
+    if (isShutdown) {
+      throw ShutdownChannelGroupException()
+    }
+    val added = channels.add(channel)
+    if (added) {
+      logger.debug("Added channel {} to group {}", System.identityHashCode(channel),
+        System.identityHashCode(this))
+    }
+    return added
+  }
+
+  override fun deRegister(channel: Channel): Boolean {
+    val removed = channels.remove(channel)
+    if (removed) {
+      logger.debug("Removed channel {} from group {}", System.identityHashCode(channel),
+        System.identityHashCode(this))
+      if (isShutdown && channels.isEmpty()) {
+        terminate()
+      }
+    }
+    return removed
+  }
+
+  override fun selectorFor(channel: SelectableChannel): CoroutineSelector {
+    val selectors = this.selectors ?: throw IllegalStateException(
+      "Access to terminated ChannelGroup by unregistered channel")
+    return selectors[System.identityHashCode(channel).rem(selectors.size)]
+  }
+
+  override val isTerminated: Boolean
+    get() {
+      if (isShutdown && !wasTerminated && channels.isEmpty()) {
+        terminate()
+        return true
+      }
+      return wasTerminated
+    }
+
+  override fun shutdown() {
+    isShutdown = true
+    logger.debug("Shutdown channel group {}", System.identityHashCode(this))
+    if (!wasTerminated && channels.isEmpty()) {
+      terminate()
+    }
+  }
+
+  override fun shutdownNow() {
+    shutdown()
+    channels.forEach { it.close() }
+  }
+
+  override suspend fun awaitTermination() {
+    if (wasTerminated) {
+      return
+    }
+    suspendCoroutine<Unit> { cont ->
+      pendingTermination.add(cont)
+      if (isShutdown && channels.isEmpty()) {
+        terminate()
+      }
+    }
+  }
+
+  private fun terminate() {
+    check(isShutdown)
+    wasTerminated = true
+    logger.debug("Terminated channel group {}", System.identityHashCode(this))
+    while (true) {
+      (pendingTermination.poll() ?: break).resume(Unit)
+    }
+    val selectors = this.selectors
+    this.selectors = null
+    selectors?.let { it.map { selector -> selector.close() } }
+  }
+}

--- a/net-coroutines/src/main/kotlin/net/consensys/cava/net/coroutines/experimental/CoroutineSelector.kt
+++ b/net-coroutines/src/main/kotlin/net/consensys/cava/net/coroutines/experimental/CoroutineSelector.kt
@@ -27,18 +27,48 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.experimental.Continuation
+import kotlin.coroutines.experimental.suspendCoroutine
 
 /**
- * A common co-routine selector pool.
- *
- * This pool is created with a selector per available processors.
+ * A selector for co-routine based channel IO.
  */
-val CommonCoroutineSelector: CoroutineSelector = CoroutineSelectorPool.open(Runtime.getRuntime().availableProcessors())
+sealed class CoroutineSelector {
 
-/**
- * A selector for coroutine-based channel IO.
- */
-interface CoroutineSelector {
+  companion object {
+    internal val DEFAULT_THREAD_FACTORY =
+      ThreadFactoryBuilder().setNameFormat("selection-dispatch-%d").setDaemon(true).build()
+
+    /**
+     * Open a co-routine selector.
+     *
+     * @param executor An executor for obtaining a thread to run the selection loop.
+     * @param loggerProvider A provider for logger instances.
+     * @param selectTimeout The maximum time the selection operation will wait before checking for closed channels.
+     * @param idleTimeout The minimum idle time before the selection loop of the selector exits.
+     * @return A co-routine selector.
+     */
+    fun open(
+      executor: Executor = Executors.newSingleThreadExecutor(DEFAULT_THREAD_FACTORY),
+      loggerProvider: LoggerProvider = LoggerProvider.nullProvider(),
+      selectTimeout: Long = 1000,
+      idleTimeout: Long = 10000
+    ): CoroutineSelector {
+      require(selectTimeout > 0) { "selectTimeout must be larger than zero" }
+      require(idleTimeout >= 0) { "idleTimeout must be positive" }
+      val idleTasks = idleTimeout / selectTimeout
+      require(idleTasks <= Integer.MAX_VALUE) { "idleTimeout is too large" }
+
+      return SingleThreadCoroutineSelector(executor, Selector.open(), loggerProvider, selectTimeout, idleTasks.toInt())
+    }
+  }
+
+  /**
+   * Indicates whether the selector is open or not.
+   *
+   * @return `true` if the selector is open.
+   */
+  abstract fun isOpen(): Boolean
 
   /**
    * Wait for a channel to become ready for any of the specified operations.
@@ -48,7 +78,7 @@ interface CoroutineSelector {
    *   [SelectionKey.OP_READ] and/or [SelectionKey.OP_WRITE].
    * @throws ClosedSelectorException If the co-routine selector has been closed.
    */
-  suspend fun select(channel: SelectableChannel, ops: Int)
+  abstract suspend fun select(channel: SelectableChannel, ops: Int)
 
   /**
    * Cancel any suspended calls to [select] for the specified channel.
@@ -58,379 +88,346 @@ interface CoroutineSelector {
    * @return `true` if any suspensions were cancelled.
    * @throws ClosedSelectorException If the co-routine selector has been closed.
    */
-  suspend fun cancelSelections(channel: SelectableChannel, cause: Throwable? = null): Boolean
+  abstract suspend fun cancelSelections(channel: SelectableChannel, cause: Throwable? = null): Boolean
 
   /**
    * Force the selection loop, if running, to wake up and process any closed channels.
    *
    * @throws ClosedSelectorException If the co-routine selector has been closed.
    */
-  fun wakeup()
+  abstract fun wakeup()
 
   /**
    * Close the co-routine selector.
    */
-  fun close()
+  abstract fun close()
+
+  /**
+   * Close the co-routine selector and wait for all suspensions to be cancelled.
+   */
+  abstract suspend fun closeNow()
 }
 
-/**
- * A pool of co-routine selectors.
- */
-class CoroutineSelectorPool private constructor(
-  poolSize: Int,
+internal class SingleThreadCoroutineSelector(
   private val executor: Executor,
+  private val selector: Selector,
   loggerProvider: LoggerProvider,
   private val selectTimeout: Long,
   private val idleTasks: Int
-) : CoroutineSelector {
+) : CoroutineSelector() {
 
-  companion object {
-    /**
-     * Open a co-routine selection pool.
-     *
-     * @param poolSize The number of selectors in the pool.
-     * @param executor An executor for obtaining threads to run the selection loop of each selector.
-     * @param loggerProvider A provider for logger instances.
-     * @param selectTimeout The maximum time the selection operation will wait before checking for closed channels.
-     * @param idleTimeout The minimum idle time before the selection loop of a selector exits.
-     * @return A co-routine selection pool.
-     */
-    fun open(
-      poolSize: Int,
-      executor: Executor = Executors.newFixedThreadPool(poolSize,
-        ThreadFactoryBuilder().setNameFormat("selection-dispatch-%d").build()),
-      loggerProvider: LoggerProvider = LoggerProvider.nullProvider(),
-      selectTimeout: Long = 1000,
-      idleTimeout: Long = 10000
-    ): CoroutineSelector {
-      require(poolSize > 0) { "poolSize must be larger than zero" }
-      require(selectTimeout > 0) { "selectTimeout must be larger than zero" }
-      require(idleTimeout >= 0) { "idleTimeout must be positive" }
-      val idleTasks = idleTimeout / selectTimeout
-      require(idleTasks <= Integer.MAX_VALUE) { "idleTimeout is too large" }
+  private val logger = loggerProvider.getLogger(CoroutineSelector::class.java)
 
-      return if (poolSize == 1) {
-        SingleCoroutineSelector(executor, Selector.open(), loggerProvider, selectTimeout, idleTasks.toInt())
-      } else {
-        CoroutineSelectorPool(poolSize, executor, loggerProvider, selectTimeout, idleTasks.toInt())
-      }
-    }
+  private val pendingInterests = ConcurrentLinkedQueue<SelectionInterest>()
+  private val pendingCancellations = ConcurrentLinkedQueue<SelectionCancellation>()
+  private val pendingCloses = ConcurrentLinkedQueue<Continuation<Unit>>()
+  private val outstandingTasks = AtomicInteger(0)
+  private val registeredKeys = HashSet<SelectionKey>()
+
+  init {
+    require(selector.isOpen) { "Selector is closed" }
+    require(selector.keys().isEmpty()) { "Selector already has selection keys" }
   }
 
-  private val selectors: Array<CoroutineSelector> = Array(poolSize) {
-    SingleCoroutineSelector(executor, Selector.open(), loggerProvider, selectTimeout, idleTasks)
-  }
+  override fun isOpen(): Boolean = selector.isOpen
 
   override suspend fun select(channel: SelectableChannel, ops: Int) {
-    selectors[System.identityHashCode(channel).rem(selectors.size)].select(channel, ops)
+    require(!channel.isBlocking) { "AsyncChannel must be set to non blocking" }
+    require(ops != 0) { "ops must not be zero" }
+    require(ops and channel.validOps().inv() == 0) { "Invalid operations for channel" }
+    if (!selector.isOpen) {
+      throw ClosedSelectorException()
+    }
+    suspendCancellableCoroutine { cont: CancellableContinuation<Unit> ->
+      // increment tasks first to keep selection loop running while we add a new pending interest
+      val isRunning = incrementTasks()
+      pendingInterests.add(SelectionInterest(cont, channel, ops))
+      wakeup(isRunning)
+    }
   }
 
   override suspend fun cancelSelections(channel: SelectableChannel, cause: Throwable?): Boolean {
-    return selectors[System.identityHashCode(channel).rem(selectors.size)].cancelSelections(channel)
+    if (!selector.isOpen) {
+      throw ClosedSelectorException()
+    }
+    check(selector.isOpen) { "Selector is closed" }
+    return suspendCancellableCoroutine { cont: CancellableContinuation<Boolean> ->
+      // increment tasks first to keep selection loop running while we add a new pending cancellation
+      val isRunning = incrementTasks()
+      pendingCancellations.add(SelectionCancellation(channel, cause, cont))
+      wakeup(isRunning)
+    }
   }
 
   override fun wakeup() {
-    selectors.forEach { it.wakeup() }
+    if (!selector.isOpen) {
+      throw ClosedSelectorException()
+    }
+    selector.wakeup()
   }
 
   override fun close() {
-    selectors.forEach { it.close() }
+    selector.close()
   }
 
-  private class SingleCoroutineSelector(
-    private val executor: Executor,
-    private val selector: Selector,
-    loggerProvider: LoggerProvider,
-    private val selectTimeout: Long,
-    private val idleTasks: Int
-  ) : CoroutineSelector {
-
-    private val logger = loggerProvider.getLogger(CoroutineSelectorPool::class.java)
-
-    private val pendingInterests = ConcurrentLinkedQueue<SelectionInterest>()
-    private val pendingCancellations = ConcurrentLinkedQueue<SelectionCancellation>()
-    private val outstandingTasks = AtomicInteger(0)
-    private val registeredKeys = HashSet<SelectionKey>()
-
-    init {
-      require(selector.isOpen) { "Selector is closed" }
-      require(selector.keys().isEmpty()) { "Selector already has selection keys" }
-    }
-
-    override suspend fun select(channel: SelectableChannel, ops: Int) {
-      require(!channel.isBlocking) { "AsyncChannel must be set to non blocking" }
-      require(ops != 0) { "ops must not be zero" }
-      require(ops and channel.validOps().inv() == 0) { "Invalid operations for channel" }
-      if (!selector.isOpen) {
-        throw ClosedSelectorException()
-      }
-      suspendCancellableCoroutine { cont: CancellableContinuation<Unit> ->
-        // increment tasks first to keep selection loop running while we add a new pending interest
-        val isRunning = incrementTasks()
-        pendingInterests.add(SelectionInterest(cont, channel, ops))
-        wakeup(isRunning)
+  override suspend fun closeNow() {
+    selector.close()
+    suspendCoroutine { cont: Continuation<Unit> ->
+      pendingCloses.add(cont)
+      if (outstandingTasks.get() == 0) {
+        processPendingCloses()
       }
     }
+  }
 
-    override suspend fun cancelSelections(channel: SelectableChannel, cause: Throwable?): Boolean {
-      if (!selector.isOpen) {
-        throw ClosedSelectorException()
-      }
-      check(selector.isOpen) { "Selector is closed" }
-      return suspendCancellableCoroutine { cont: CancellableContinuation<Boolean> ->
-        // increment tasks first to keep selection loop running while we add a new pending cancellation
-        val isRunning = incrementTasks()
-        pendingCancellations.add(SelectionCancellation(channel, cause, cont))
-        wakeup(isRunning)
-      }
-    }
+  private fun incrementTasks(): Boolean = outstandingTasks.getAndIncrement() != 0
 
-    override fun wakeup() {
-      if (!selector.isOpen) {
-        throw ClosedSelectorException()
-      }
+  private fun wakeup(isRunning: Boolean) {
+    if (isRunning) {
+      logger.debug("Selector {}: Interrupting selection loop", System.identityHashCode(selector))
       selector.wakeup()
+    } else {
+      executor.execute(this::selectionLoop)
     }
+  }
 
-    override fun close() {
-      selector.close()
-    }
+  private fun selectionLoop() {
+    logger.debug("Selector {}: Starting selection loop", System.identityHashCode(selector))
+    try {
+      // allow the selector to cleanup any outstanding cancelled keys before starting the loop
+      selector.selectNow()
+      outstandingTasks.addAndGet(idleTasks)
+      var idleCount = 0
 
-    private fun incrementTasks(): Boolean = outstandingTasks.getAndIncrement() != 0
-
-    private fun wakeup(isRunning: Boolean) {
-      if (isRunning) {
-        logger.debug("Selector {}: Interrupting selection loop", System.identityHashCode(selector))
-        selector.wakeup()
-      } else {
-        executor.execute(this::selectionLoop)
-      }
-    }
-
-    private fun selectionLoop() {
-      logger.debug("Selector {}: Starting selection loop", System.identityHashCode(selector))
-      try {
-        // allow the selector to cleanup any outstanding cancelled keys before starting the loop
-        selector.selectNow()
-        outstandingTasks.addAndGet(idleTasks)
-        var idleCount = 0
-
-        while (true) {
-          // add pending selections before awakening selected, which allows for newly added
-          // selections to be awoken immediately and avoids trying to register to already canceled keys
-          if (processTasks(this::registerPendingSelections)) {
-            break
-          }
-          if (processTasks(this::processPendingCancellations)) {
-            break
-          }
-          if (processTasks(this::awakenSelected)) {
-            break
-          }
-
-          if (selector.keys().isEmpty()) {
-            if (outstandingTasks.decrementAndGet() == 0) {
-              break
-            }
-            idleCount++
-          } else {
-            outstandingTasks.addAndGet(idleCount)
-            idleCount = 0
-          }
-
-          selector.selectedKeys().clear()
-          // use a timeout on select, as keys cancelled via channel close wont wakeup the selector
-          selector.select(selectTimeout)
-
-          if (!selector.isOpen) {
-            cancelAll(ClosedSelectorException())
-            break
-          }
-          if (processTasks(this::cancelMissingRegistrations)) {
-            break
-          }
-        }
-        logger.debug("Selector {}: Exiting selection loop", System.identityHashCode(selector))
-      } catch (e: Throwable) {
-        selector.close()
-        logger.error(LogMessage.patternFormat("Selector {}: An unexpected exception occurred in selection loop",
-          System.identityHashCode(selector)), e)
-        cancelAll(e)
-      }
-    }
-
-    private fun processTasks(block: () -> Int): Boolean {
-      val processed = block()
-      val remaining = outstandingTasks.addAndGet(-processed)
-      check(remaining >= 0) { "More tasks processed than were outstanding" }
-      return remaining == 0
-    }
-
-    private fun registerPendingSelections(): Int {
-      var processed = 0
       while (true) {
-        val interest = pendingInterests.poll() ?: break
-        try {
-          val key = interest.channel.keyFor(selector)
-          val registered = if (key == null) {
-            registerInterest(interest)
-          } else {
-            mergeInterest(key, interest)
-          }
-          if (!registered) {
-            processed++
-          }
-        } catch (e: Throwable) {
-          interest.cont.cancel(e)
-          throw e
+        // add pending selections before awakening selected, which allows for newly added
+        // selections to be awoken immediately and avoids trying to register to already canceled keys
+        if (processTasks(this::registerPendingSelections)) {
+          break
         }
-      }
-      return processed
-    }
+        if (processTasks(this::processPendingCancellations)) {
+          break
+        }
+        if (processTasks(this::awakenSelected)) {
+          break
+        }
 
-    private fun registerInterest(interest: SelectionInterest): Boolean {
-      val key: SelectionKey
-      try {
-        key = interest.channel.register(selector, interest.ops, arrayListOf(interest))
-      } catch (e: ClosedChannelException) {
-        interest.cont.resumeWithException(e)
-        return false
-      }
-      registeredKeys.add(key)
-      logger.debug("Selector {}: Registered {}@{} for interests {}", System.identityHashCode(selector),
-        interest.channel, System.identityHashCode(interest.channel), interest.ops)
-      return true
-    }
-
-    private fun mergeInterest(key: SelectionKey, interest: SelectionInterest): Boolean {
-      val mergedInterests: Int
-      try {
-        mergedInterests = key.interestOps() or interest.ops
-        key.interestOps(mergedInterests)
-      } catch (e: CancelledKeyException) {
-        // key must have been cancelled via closing the channel
-        val exception = ClosedChannelException()
-        exception.addSuppressed(e)
-        interest.cont.resumeWithException(exception)
-        return false
-      }
-      @Suppress("UNCHECKED_CAST")
-      val interests = key.attachment() as ArrayList<SelectionInterest>
-      interests.add(interest)
-      logger.debug("Selector {}: Updated registration for channel {} to interests {}",
-        System.identityHashCode(selector), System.identityHashCode(interest.channel), mergedInterests)
-      return true
-    }
-
-    private fun processPendingCancellations(): Int {
-      var processed = 0
-      while (true) {
-        val cancellation = pendingCancellations.poll() ?: break
-        processed++
-        val key = cancellation.channel.keyFor(selector)
-        if (key != null) {
-          logger.debug("Selector {}: Cancelling registration for channel {}", System.identityHashCode(selector),
-            System.identityHashCode(cancellation.channel))
-
-          @Suppress("UNCHECKED_CAST")
-          val interests = key.attachment() as ArrayList<SelectionInterest>
-          for (interest in interests) {
-            interest.cont.cancel(cancellation.cause)
-            processed++
+        if (selector.keys().isEmpty()) {
+          if (outstandingTasks.decrementAndGet() == 0) {
+            break
           }
-          interests.clear()
-          key.cancel()
-          registeredKeys.remove(key)
-          cancellation.cont.resume(true)
+          idleCount++
         } else {
-          cancellation.cont.resume(false)
+          outstandingTasks.addAndGet(idleCount)
+          idleCount = 0
+        }
+
+        selector.selectedKeys().clear()
+        // use a timeout on select, as keys cancelled via channel close wont wakeup the selector
+        selector.select(selectTimeout)
+
+        if (!selector.isOpen) {
+          cancelAll(ClosedSelectorException())
+          break
+        }
+        if (processTasks(this::cancelMissingRegistrations)) {
+          break
         }
       }
-      return processed
+      logger.debug("Selector {}: Exiting selection loop", System.identityHashCode(selector))
+      processPendingCloses()
+    } catch (e: Throwable) {
+      selector.close()
+      logger.error(LogMessage.patternFormat("Selector {}: An unexpected exception occurred in selection loop",
+        System.identityHashCode(selector)), e)
+      cancelAll(e)
+      processPendingCloses(e)
     }
+  }
 
-    private fun awakenSelected(): Int {
-      var awoken = 0
-      val selectedKeys = selector.selectedKeys()
-      for (key in selectedKeys) {
+  private fun processTasks(block: () -> Int): Boolean {
+    val processed = block()
+    val remaining = outstandingTasks.addAndGet(-processed)
+    check(remaining >= 0) { "More tasks processed than were outstanding" }
+    return remaining == 0
+  }
+
+  private fun registerPendingSelections(): Int {
+    var processed = 0
+    while (true) {
+      val interest = pendingInterests.poll() ?: break
+      try {
+        val key = interest.channel.keyFor(selector)
+        val registered = if (key == null) {
+          registerInterest(interest)
+        } else {
+          mergeInterest(key, interest)
+        }
+        if (!registered) {
+          processed++
+        }
+      } catch (e: Throwable) {
+        interest.cont.resumeWithException(e)
+        throw e
+      }
+    }
+    return processed
+  }
+
+  private fun registerInterest(interest: SelectionInterest): Boolean {
+    val key: SelectionKey
+    try {
+      key = interest.channel.register(selector, interest.ops, arrayListOf(interest))
+    } catch (e: ClosedChannelException) {
+      interest.cont.resumeWithException(e)
+      return false
+    }
+    registeredKeys.add(key)
+    logger.debug("Selector {}: Registered {}@{} for interests {}", System.identityHashCode(selector),
+      interest.channel, System.identityHashCode(interest.channel), interest.ops)
+    return true
+  }
+
+  private fun mergeInterest(key: SelectionKey, interest: SelectionInterest): Boolean {
+    val mergedInterests: Int
+    try {
+      mergedInterests = key.interestOps() or interest.ops
+      key.interestOps(mergedInterests)
+    } catch (e: CancelledKeyException) {
+      // key must have been cancelled via closing the channel
+      val exception = ClosedChannelException()
+      exception.addSuppressed(e)
+      interest.cont.resumeWithException(exception)
+      return false
+    }
+    @Suppress("UNCHECKED_CAST")
+    val interests = key.attachment() as ArrayList<SelectionInterest>
+    interests.add(interest)
+    logger.debug("Selector {}: Updated registration for channel {} to interests {}",
+      System.identityHashCode(selector), System.identityHashCode(interest.channel), mergedInterests)
+    return true
+  }
+
+  private fun processPendingCancellations(): Int {
+    var processed = 0
+    while (true) {
+      val cancellation = pendingCancellations.poll() ?: break
+      processed++
+      val key = cancellation.channel.keyFor(selector)
+      if (key != null) {
+        logger.debug("Selector {}: Cancelling registration for channel {}", System.identityHashCode(selector),
+          System.identityHashCode(cancellation.channel))
+
         @Suppress("UNCHECKED_CAST")
         val interests = key.attachment() as ArrayList<SelectionInterest>
-
-        if (!key.isValid) {
-          // channel must have been closed
-          val cause = ClosedChannelException()
-          interests.forEach { it.cont.cancel(cause) }
-          interests.clear()
-          continue
+        for (interest in interests) {
+          interest.cont.cancel(cancellation.cause)
+          processed++
         }
-
-        val readyOps = key.readyOps()
-        logger.debug("Selector {}: Channel {} selected for interests {}", System.identityHashCode(selector),
-          System.identityHashCode(key.channel()), readyOps)
-        var remainingOps = 0
-
-        val it = interests.iterator()
-        while (it.hasNext()) {
-          val interest = it.next()
-          // if any of the interests are set, then resume the continuation
-          if ((interest.ops and readyOps) != 0) {
-            interest.cont.resume(Unit)
-            it.remove()
-            awoken++
-          } else {
-            remainingOps = remainingOps or interest.ops
-          }
-        }
-        key.interestOps(remainingOps)
-        if (interests.isEmpty()) {
-          registeredKeys.remove(key)
-          key.cancel()
-        }
+        interests.clear()
+        key.cancel()
+        registeredKeys.remove(key)
+        cancellation.cont.resume(true)
+      } else {
+        cancellation.cont.resume(false)
       }
-      return awoken
     }
+    return processed
+  }
 
-    private fun cancelMissingRegistrations(): Int {
-      val selectorKeys = selector.keys()
-      if (selectorKeys.size == registeredKeys.size) {
-        // assume sets of the same size contain the same members
-        return 0
+  private fun processPendingCloses() {
+    while (true) {
+      (pendingCloses.poll() ?: break).resume(Unit)
+    }
+  }
+
+  private fun processPendingCloses(e: Throwable) {
+    while (true) {
+      (pendingCloses.poll() ?: break).resumeWithException(e)
+    }
+  }
+
+  private fun awakenSelected(): Int {
+    var awoken = 0
+    val selectedKeys = selector.selectedKeys()
+    for (key in selectedKeys) {
+      @Suppress("UNCHECKED_CAST")
+      val interests = key.attachment() as ArrayList<SelectionInterest>
+
+      if (!key.isValid) {
+        // channel must have been closed
+        val cause = ClosedChannelException()
+        interests.forEach { it.cont.resumeWithException(cause) }
+        interests.clear()
+        continue
       }
 
-      // There should only be less keys in the selector, as keys will vanish after cancellation via closing their channel
-      check(selectorKeys.size < registeredKeys.size) { "More registered keys than are outstanding" }
+      val readyOps = key.readyOps()
+      logger.debug("Selector {}: Channel {} selected for interests {}", System.identityHashCode(selector),
+        System.identityHashCode(key.channel()), readyOps)
+      var remainingOps = 0
 
-      var processed = 0
-      registeredKeys.removeIf { key ->
-        if (selectorKeys.contains(key)) {
-          false
+      val it = interests.iterator()
+      while (it.hasNext()) {
+        val interest = it.next()
+        // if any of the interests are set, then resume the continuation
+        if ((interest.ops and readyOps) != 0) {
+          interest.cont.resume(Unit)
+          it.remove()
+          awoken++
         } else {
-          val cause = ClosedChannelException()
-          @Suppress("UNCHECKED_CAST")
-          val interests = key.attachment() as ArrayList<SelectionInterest>
-          for (interest in interests) {
-            interest.cont.cancel(cause)
-            processed++
-          }
-          interests.clear()
-          key.cancel()
-          true
+          remainingOps = remainingOps or interest.ops
         }
       }
-      return processed
+      key.interestOps(remainingOps)
+      if (interests.isEmpty()) {
+        registeredKeys.remove(key)
+        key.cancel()
+      }
+    }
+    return awoken
+  }
+
+  private fun cancelMissingRegistrations(): Int {
+    val selectorKeys = selector.keys()
+    if (selectorKeys.size == registeredKeys.size) {
+      // assume sets of the same size contain the same members
+      return 0
     }
 
-    private fun cancelAll(e: Throwable) {
-      pendingInterests.forEach { it.cont.cancel(e) }
-      pendingInterests.clear()
-      registeredKeys.forEach { key ->
+    // There should only be less keys in the selector, as keys will vanish after cancellation via closing their channel
+    check(selectorKeys.size < registeredKeys.size) { "More registered keys than are outstanding" }
+
+    var processed = 0
+    registeredKeys.removeIf { key ->
+      if (selectorKeys.contains(key)) {
+        false
+      } else {
+        val cause = ClosedChannelException()
         @Suppress("UNCHECKED_CAST")
-        (key.attachment() as ArrayList<SelectionInterest>).forEach { it.cont.cancel(e) }
+        val interests = key.attachment() as ArrayList<SelectionInterest>
+        for (interest in interests) {
+          interest.cont.resumeWithException(cause)
+          processed++
+        }
+        interests.clear()
+        key.cancel()
+        true
       }
-      registeredKeys.clear()
-      pendingCancellations.clear()
-      outstandingTasks.set(0)
     }
+    return processed
+  }
+
+  private fun cancelAll(e: Throwable) {
+    pendingInterests.forEach { it.cont.resumeWithException(e) }
+    pendingInterests.clear()
+    registeredKeys.forEach { key ->
+      @Suppress("UNCHECKED_CAST")
+      (key.attachment() as ArrayList<SelectionInterest>).forEach { it.cont.resumeWithException(e) }
+    }
+    registeredKeys.clear()
+    pendingCancellations.clear()
+    outstandingTasks.set(0)
   }
 
   private data class SelectionInterest(

--- a/net-coroutines/src/test/kotlin/net/consensys/cava/net/coroutines/experimental/CoroutineChannelGroupTest.kt
+++ b/net-coroutines/src/test/kotlin/net/consensys/cava/net/coroutines/experimental/CoroutineChannelGroupTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.net.coroutines.experimental
+
+import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.experimental.runBlocking
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.nio.channels.ShutdownChannelGroupException
+
+internal class CoroutineChannelGroupTest {
+
+  @Test
+  fun shouldImmediatelyTerminateEmptyGroup() {
+    val group = CoroutineChannelGroup.open()
+    group.shutdown()
+    assertTrue(group.isShutdown)
+    assertTrue(group.isTerminated)
+  }
+
+  @Test
+  fun shouldTerminateGroupWhenAllChannelsClosed() {
+    val group = CoroutineChannelGroup.open()
+    val channel = CoroutineServerSocketChannel.open(group)
+    group.shutdown()
+    assertTrue(group.isShutdown)
+    assertFalse(group.isTerminated)
+    channel.close()
+    assertTrue(group.isTerminated)
+  }
+
+  @Test
+  fun shouldNotAllowNewChannelsAfterShutdown() {
+    val group = CoroutineChannelGroup.open()
+    CoroutineServerSocketChannel.open(group)
+    group.shutdown()
+    assertThrows<ShutdownChannelGroupException> { CoroutineServerSocketChannel.open(group) }
+  }
+
+  @Test
+  fun shouldTerminateWhenAllChannelAreClosed() {
+    val group = CoroutineChannelGroup.open()
+    val channel = CoroutineServerSocketChannel.open(group)
+    var didBlock = false
+    val task = async {
+      group.awaitTermination()
+      assertTrue(didBlock)
+    }
+    group.shutdown()
+    Thread.sleep(100)
+    assertFalse(group.isTerminated)
+    didBlock = true
+    channel.close()
+    runBlocking { task.await() }
+    assertTrue(group.isTerminated)
+  }
+
+  @Test
+  fun shutdownNowShouldCloseChannels() {
+    val group = CoroutineChannelGroup.open()
+    val channel = CoroutineServerSocketChannel.open(group)
+    assertTrue(channel.isOpen)
+    group.shutdownNow()
+    assertFalse(channel.isOpen)
+    assertTrue(group.isTerminated)
+  }
+
+  @Test
+  fun shutdownNowShouldResumeCoroutinesAwaitingTermination() {
+    val group = CoroutineChannelGroup.open()
+    val channel = CoroutineServerSocketChannel.open(group)
+    var didBlock = false
+    val task = async {
+      group.awaitTermination()
+      assertTrue(didBlock)
+    }
+    Thread.sleep(100)
+    didBlock = true
+    group.shutdownNow()
+    assertTrue(group.isTerminated)
+    runBlocking { task.await() }
+    assertFalse(channel.isOpen)
+  }
+
+  @Test
+  fun awaitTerminationShouldReturnImmediatelyForTerminatedGroup() {
+    val group = CoroutineChannelGroup.open()
+    group.shutdown()
+    runBlocking { group.awaitTermination() }
+  }
+}


### PR DESCRIPTION
Rather than initializing CoroutineChannels with a CoroutineSelector, instead use a generic CoroutineChannelGroup. This allows for alternative selection mechanisms to, potentially, be supported (e.g. aio). Additionally, it supports shutting down all channels in the group and checking for group termination.