### PR TITLE
Add CoroutineLatch

### DIFF
--- a/concurrent-coroutines/build.gradle
+++ b/concurrent-coroutines/build.gradle
@@ -3,4 +3,9 @@ description = 'Kotlin coroutine extensions for cava concurrency primitives.'
 dependencies {
   compile project(':concurrent')
   compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core'
+
+  testCompile 'org.junit.jupiter:junit-jupiter-api'
+  testCompile 'org.junit.jupiter:junit-jupiter-params'
+
+  testRuntime 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/concurrent-coroutines/src/main/kotlin/net/consensys/cava/concurrent/coroutines/experimental/CoroutineLatch.kt
+++ b/concurrent-coroutines/src/main/kotlin/net/consensys/cava/concurrent/coroutines/experimental/CoroutineLatch.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.concurrent.coroutines.experimental
+
+import kotlinx.coroutines.experimental.suspendCancellableCoroutine
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.experimental.Continuation
+
+/**
+ * A co-routine synchronization aid that allows co-routines to wait until a set of operations being performed
+ * has completed.
+ *
+ * The latch is initialized with a given count. If the latch count is greater than zero, the `await()` method will
+ * suspend until the count reaches zero due to invocations of the `countDown()` method, at which point all suspended
+ * co-routines will be resumed.
+ *
+ * Unlike the Java `CountDownLatch`, this latch allows the count to be increased via invocation of the `countUp()`
+ * method. Increasing the count from zero will result in calls to `await()` suspending again. Note that the count may
+ * be negative, requiring multiple calls to `countUp()` before calls to `await()` suspend.
+ *
+ * @param initial The initial count of the latch, which may be positive, zero, or negative.
+ * @constructor A latch.
+ */
+class CoroutineLatch(initial: Int) {
+
+  private val atomicCount = AtomicInteger(initial)
+  private var waitingCoroutines = mutableListOf<Continuation<Unit>>()
+
+  /**
+   * The current latch count.
+   */
+  val count: Int
+    get() = atomicCount.get()
+
+  /**
+   * Indicates if the latch is open (`count <= 0`).
+   */
+  val isOpen: Boolean
+    get() = atomicCount.get() <= 0
+
+  /**
+   * Decrease the latch count, potentially opening the latch and awakening suspending co-routines.
+   *
+   * @return `true` if the latch was opened as a result of this invocation.
+   */
+  fun countDown(): Boolean {
+    var toAwaken: List<Continuation<Unit>>? = null
+    synchronized(this) {
+      val result = atomicCount.decrementAndGet()
+      if (result == 0) {
+        toAwaken = waitingCoroutines
+        waitingCoroutines = mutableListOf()
+      }
+    }
+    toAwaken?.forEach { it.resume(Unit) }
+    return toAwaken != null
+  }
+
+  /**
+   * Increase the latch count, potentially closing the latch.
+   *
+   * @return `true` if the latch was closed as a result of this invocation.
+   */
+  fun countUp(): Boolean = atomicCount.incrementAndGet() == 1
+
+  /**
+   * Await the latch opening. If already open, return without suspending.
+   */
+  suspend fun await() {
+    if (atomicCount.get() <= 0) {
+      return
+    }
+    suspendCancellableCoroutine { cont: Continuation<Unit> ->
+      try {
+        var suspended = false
+        synchronized(this) {
+          suspended = atomicCount.get() > 0
+          if (suspended) {
+            waitingCoroutines.add(cont)
+          }
+        }
+        if (!suspended) {
+          cont.resume(Unit)
+        }
+      } catch (e: Throwable) {
+        cont.resumeWithException(e)
+      }
+    }
+  }
+}

--- a/concurrent-coroutines/src/test/kotlin/net/consensys/cava/concurrent/coroutines/experimental/CoroutineLatchTest.kt
+++ b/concurrent-coroutines/src/test/kotlin/net/consensys/cava/concurrent/coroutines/experimental/CoroutineLatchTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.concurrent.coroutines.experimental
+
+import kotlinx.coroutines.experimental.TimeoutCancellationException
+import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.experimental.withTimeout
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class CoroutineLatchTest {
+
+  @Test
+  fun shouldntSuspendWhenLatchIsOpen() = runBlocking {
+    withTimeout(1) {
+      CoroutineLatch(0).await()
+    }
+    withTimeout(1) {
+      CoroutineLatch(-1).await()
+    }
+  }
+
+  @Test
+  fun shouldUnsuspendWhenLatchOpens() {
+    val latch = CoroutineLatch(2)
+    assertFalse(latch.isOpen)
+    assertEquals(2, latch.count)
+
+    var ok = false
+    var done = false
+    val job = async {
+      latch.await()
+      assertTrue(ok, "failed to suspend")
+      done = true
+    }
+
+    Thread.sleep(100)
+    assertFalse(latch.countDown())
+    assertFalse(latch.isOpen)
+    assertEquals(1, latch.count)
+
+    Thread.sleep(100)
+    assertFalse(done, "woke up too early")
+
+    ok = true
+    assertTrue(latch.countDown())
+    assertTrue(latch.isOpen)
+    assertEquals(0, latch.count)
+    runBlocking { job.await() }
+    assertTrue(done, "failed to wakeup")
+  }
+
+  @Test
+  fun shouldSuspendWhenLatchCloses() = runBlocking {
+    val latch = CoroutineLatch(-1)
+    assertTrue(latch.isOpen)
+    assertEquals(-1, latch.count)
+
+    withTimeout(1) {
+      latch.await()
+    }
+
+    assertFalse(latch.countUp())
+    assertTrue(latch.isOpen)
+    assertEquals(0, latch.count)
+
+    withTimeout(1) {
+      latch.await()
+    }
+
+    assertTrue(latch.countUp())
+    assertFalse(latch.isOpen)
+    assertEquals(1, latch.count)
+
+    var ok = false
+    var done = false
+    val job = async {
+      latch.await()
+      assertTrue(ok, "failed to suspend")
+      done = true
+    }
+
+    ok = true
+    assertTrue(latch.countDown())
+    assertTrue(latch.isOpen)
+    job.await()
+    assertTrue(done, "failed to wakeup")
+  }
+
+  @Test
+  fun shouldTimeoutWhenBlocked() {
+    assertThrows<TimeoutCancellationException> {
+      runBlocking {
+        withTimeout(1) {
+          CoroutineLatch(1).await()
+        }
+      }
+    }
+  }
+}

--- a/net-coroutines/src/main/kotlin/net/consensys/cava/net/coroutines/experimental/CoroutineChannelGroup.kt
+++ b/net-coroutines/src/main/kotlin/net/consensys/cava/net/coroutines/experimental/CoroutineChannelGroup.kt
@@ -112,7 +112,7 @@ internal class CoroutineSelectorChannelGroup(
   idleTimeout: Long
 ) : CoroutineChannelGroup() {
 
-  private val logger = loggerProvider.getLogger(CoroutineSelectorChannelGroup::class.java)
+  private val logger = loggerProvider.getLogger(CoroutineChannelGroup::class.java)
 
   private var selectors: Array<CoroutineSelector>? = Array(nSelectors) {
     CoroutineSelector.open(executor, loggerProvider, selectTimeout, idleTimeout)


### PR DESCRIPTION
A co-routine synchronization aid that allows co-routines to wait until a set of operations being performed has completed.

Note: this is a naive implementation using a synchronizing lock, and could be improved in future.

Also makes some small improvements to logging and error handling in co-routine network selectors.