### PR TITLE
Update SECP256K1 encoding of v (recovery id)

### DIFF
--- a/bytes/src/main/java/net/consensys/cava/bytes/Bytes.java
+++ b/bytes/src/main/java/net/consensys/cava/bytes/Bytes.java
@@ -346,7 +346,7 @@ public interface Bytes {
    *
    * @param str The hexadecimal string to parse, which may or may not start with "0x".
    * @return The value corresponding to {@code str}.
-   * @throws IllegalArgumentException if {@code str} does not correspond to valid hexadecimal representation.
+   * @throws IllegalArgumentException if {@code str} does not correspond to a valid hexadecimal representation.
    */
   static Bytes fromHexStringLenient(CharSequence str) {
     checkNotNull(str);
@@ -365,8 +365,8 @@ public interface Bytes {
    *        {@code str}. If it is strictly bigger those bytes from {@code str}, the returned value will be left padded
    *        with zeros.
    * @return A value of size {@code destinationSize} corresponding to {@code str} potentially left-padded.
-   * @throws IllegalArgumentException if {@code str} does not correspond to valid hexadecimal representation, represents
-   *         more bytes than {@code destinationSize} or {@code destinationSize &lt; 0}.
+   * @throws IllegalArgumentException if {@code str} does not correspond to a valid hexadecimal representation,
+   *         represents more bytes than {@code destinationSize} or {@code destinationSize &lt; 0}.
    */
   static Bytes fromHexStringLenient(CharSequence str, int destinationSize) {
     checkNotNull(str);
@@ -382,7 +382,7 @@ public interface Bytes {
    *
    * @param str The hexadecimal string to parse, which may or may not start with "0x".
    * @return The value corresponding to {@code str}.
-   * @throws IllegalArgumentException if {@code str} does not correspond to valid hexadecimal representation, or is of
+   * @throws IllegalArgumentException if {@code str} does not correspond to a valid hexadecimal representation, or is of
    *         an odd length.
    */
   static Bytes fromHexString(CharSequence str) {
@@ -401,9 +401,9 @@ public interface Bytes {
    *        {@code str}. If it is strictly bigger those bytes from {@code str}, the returned value will be left padded
    *        with zeros.
    * @return A value of size {@code destinationSize} corresponding to {@code str} potentially left-padded.
-   * @throws IllegalArgumentException if {@code str} does correspond to valid hexadecimal representation, or is of an
+   * @throws IllegalArgumentException if {@code str} does correspond to a valid hexadecimal representation, or is of an
    *         odd length.
-   * @throws IllegalArgumentException if {@code str} does not correspond to valid hexadecimal representation, or is of
+   * @throws IllegalArgumentException if {@code str} does not correspond to a valid hexadecimal representation, or is of
    *         an odd length, or represents more bytes than {@code destinationSize} or {@code destinationSize &lt; 0}.
    */
   static Bytes fromHexString(CharSequence str, int destinationSize) {

--- a/bytes/src/main/java/net/consensys/cava/bytes/Bytes.java
+++ b/bytes/src/main/java/net/consensys/cava/bytes/Bytes.java
@@ -23,7 +23,9 @@ import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.security.MessageDigest;
+import java.security.SecureRandom;
 import java.util.Arrays;
+import java.util.Random;
 
 import io.netty.buffer.ByteBuf;
 import io.vertx.core.buffer.Buffer;
@@ -408,6 +410,29 @@ public interface Bytes {
     checkNotNull(str);
     checkArgument(destinationSize >= 0, "Invalid negative destination size %s", destinationSize);
     return BytesValues.fromHexString(str, destinationSize, false);
+  }
+
+  /**
+   * Generate random bytes.
+   *
+   * @param size The number of bytes to generate.
+   * @return A value containing the desired number of random bytes.
+   */
+  static Bytes random(int size) {
+    return random(size, new SecureRandom());
+  }
+
+  /**
+   * Generate random bytes.
+   *
+   * @param size The number of bytes to generate.
+   * @param generator The generator for random bytes.
+   * @return A value containing the desired number of random bytes.
+   */
+  static Bytes random(int size, Random generator) {
+    byte[] array = new byte[size];
+    generator.nextBytes(array);
+    return Bytes.wrap(array);
   }
 
   /** @return The number of bytes this value represents. */

--- a/bytes/src/main/java/net/consensys/cava/bytes/Bytes32.java
+++ b/bytes/src/main/java/net/consensys/cava/bytes/Bytes32.java
@@ -139,8 +139,8 @@ public interface Bytes32 extends Bytes {
    *        less than 32 bytes, in which case the result is left padded with zeros (see {@link #fromHexStringStrict} if
    *        this is not what you want).
    * @return The value corresponding to {@code str}.
-   * @throws IllegalArgumentException if {@code str} does not correspond to valid hexadecimal representation or contains
-   *         more than 32 bytes.
+   * @throws IllegalArgumentException if {@code str} does not correspond to a valid hexadecimal representation or
+   *         contains more than 32 bytes.
    */
   static Bytes32 fromHexStringLenient(CharSequence str) {
     checkNotNull(str);
@@ -157,7 +157,7 @@ public interface Bytes32 extends Bytes {
    *        less than 32 bytes, in which case the result is left padded with zeros (see {@link #fromHexStringStrict} if
    *        this is not what you want).
    * @return The value corresponding to {@code str}.
-   * @throws IllegalArgumentException if {@code str} does not correspond to valid hexadecimal representation, is of an
+   * @throws IllegalArgumentException if {@code str} does not correspond to a valid hexadecimal representation, is of an
    *         odd length, or contains more than 32 bytes.
    */
   static Bytes32 fromHexString(CharSequence str) {
@@ -174,7 +174,7 @@ public interface Bytes32 extends Bytes {
    *
    * @param str The hexadecimal string to parse, which may or may not start with "0x".
    * @return The value corresponding to {@code str}.
-   * @throws IllegalArgumentException if {@code str} does not correspond to valid hexadecimal representation, is of an
+   * @throws IllegalArgumentException if {@code str} does not correspond to a valid hexadecimal representation, is of an
    *         odd length or does not contain exactly 32 bytes.
    */
   static Bytes32 fromHexStringStrict(CharSequence str) {

--- a/eth-domain/src/main/java/net/consensys/cava/eth/domain/Address.java
+++ b/eth-domain/src/main/java/net/consensys/cava/eth/domain/Address.java
@@ -40,6 +40,19 @@ public final class Address {
     return new Address(bytes);
   }
 
+  /**
+   * Parse a hexadecimal string into a {@link Address}.
+   *
+   * @param str The hexadecimal string to parse, which may or may not start with "0x", and should encode exactly 20
+   *        bytes.
+   * @return The value corresponding to {@code str}.
+   * @throws IllegalArgumentException if {@code str} does not correspond to va alid hexadecimal representation
+   *         containing 20 bytes.
+   */
+  public static Address fromHexString(String str) {
+    return fromBytes(Bytes.fromHexString(str));
+  }
+
   private static final int SIZE = 20;
 
   private final Bytes delegate;

--- a/eth-domain/src/main/java/net/consensys/cava/eth/domain/Block.java
+++ b/eth-domain/src/main/java/net/consensys/cava/eth/domain/Block.java
@@ -16,6 +16,7 @@ import static java.util.Objects.requireNonNull;
 
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.rlp.RLP;
+import net.consensys.cava.rlp.RLPException;
 import net.consensys.cava.rlp.RLPReader;
 import net.consensys.cava.rlp.RLPWriter;
 
@@ -31,10 +32,22 @@ public final class Block {
    *
    * @param encoded The RLP encoded block.
    * @return The deserialized block.
+   * @throws RLPException If there is an error decoding the block.
    */
   public static Block fromBytes(Bytes encoded) {
-    requireNonNull(encoded);
     return RLP.decodeList(encoded, Block::readFrom);
+  }
+
+  /**
+   * Parse a hexadecimal string into a {@link Block}.
+   *
+   * @param str The hexadecimal string to parse, which may or may not start with "0x".
+   * @return The value corresponding to {@code str}.
+   * @throws IllegalArgumentException if {@code str} does not correspond to a valid hexadecimal representation.
+   * @throws RLPException If there is an error decoding the block.
+   */
+  public static Block fromHexString(String str) {
+    return RLP.decodeList(Bytes.fromHexString(str), Block::readFrom);
   }
 
   /**
@@ -42,6 +55,7 @@ public final class Block {
    *
    * @param reader The RLP reader.
    * @return The deserialized block.
+   * @throws RLPException If there is an error decoding the block.
    */
   public static Block readFrom(RLPReader reader) {
     BlockHeader header = reader.readList(BlockHeader::readFrom);

--- a/eth-domain/src/main/java/net/consensys/cava/eth/domain/BlockBody.java
+++ b/eth-domain/src/main/java/net/consensys/cava/eth/domain/BlockBody.java
@@ -16,6 +16,7 @@ import static java.util.Objects.requireNonNull;
 
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.rlp.RLP;
+import net.consensys.cava.rlp.RLPException;
 import net.consensys.cava.rlp.RLPReader;
 import net.consensys.cava.rlp.RLPWriter;
 
@@ -34,6 +35,7 @@ public final class BlockBody {
    *
    * @param encoded The RLP encoded block.
    * @return The deserialized block body.
+   * @throws RLPException If there is an error decoding the block body.
    */
   public static BlockBody fromBytes(Bytes encoded) {
     requireNonNull(encoded);

--- a/eth-domain/src/main/java/net/consensys/cava/eth/domain/Hash.java
+++ b/eth-domain/src/main/java/net/consensys/cava/eth/domain/Hash.java
@@ -49,8 +49,20 @@ public final class Hash {
    * @return A hash.
    */
   public static Hash fromBytes(Bytes32 bytes) {
-    requireNonNull(bytes);
     return new Hash(bytes);
+  }
+
+  /**
+   * Parse a hexadecimal string into a {@link Hash}.
+   *
+   * @param str The hexadecimal string to parse, which may or may not start with "0x". That representation may contain
+   *        less than 32 bytes, in which case the result is left padded with zeros.
+   * @return The value corresponding to {@code str}.
+   * @throws IllegalArgumentException if {@code str} does not correspond to a valid hexadecimal representation or
+   *         contains more than 32 bytes.
+   */
+  public static Hash fromHexString(String str) {
+    return new Hash(Bytes32.fromHexStringLenient(str));
   }
 
   public static Hash hash(Bytes value) {

--- a/eth-domain/src/main/java/net/consensys/cava/eth/domain/Transaction.java
+++ b/eth-domain/src/main/java/net/consensys/cava/eth/domain/Transaction.java
@@ -38,6 +38,10 @@ import com.google.common.base.Objects;
  */
 public final class Transaction {
 
+  // Used for transactions that are not tied to a specific chain
+  // (e.g. does not have a chain id associated with it).
+  private static final int REPLAY_UNPROTECTED_V_BASE = 27;
+
   /**
    * Deserialize a transaction from RLP encoded bytes.
    *
@@ -97,7 +101,7 @@ public final class Transaction {
     if (!reader.isComplete()) {
       throw new InvalidRLPTypeException("Additional bytes present at the end of the RLP transaction encoding");
     }
-    return new Transaction(nonce, gasPrice, gasLimit, address, value, payload, Signature.create(v, r, s));
+    return new Transaction(nonce, gasPrice, gasLimit, address, value, payload, Signature.create(r, s, v));
   }
 
   private final UInt256 nonce;

--- a/eth-domain/src/main/java/net/consensys/cava/eth/domain/Transaction.java
+++ b/eth-domain/src/main/java/net/consensys/cava/eth/domain/Transaction.java
@@ -14,11 +14,11 @@ package net.consensys.cava.eth.domain;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
+import static net.consensys.cava.crypto.Hash.keccak256;
 
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.crypto.SECP256K1.PublicKey;
 import net.consensys.cava.crypto.SECP256K1.Signature;
-import net.consensys.cava.rlp.InvalidRLPTypeException;
 import net.consensys.cava.rlp.RLP;
 import net.consensys.cava.rlp.RLPException;
 import net.consensys.cava.rlp.RLPReader;
@@ -38,9 +38,8 @@ import com.google.common.base.Objects;
  */
 public final class Transaction {
 
-  // Used for transactions that are not tied to a specific chain
-  // (e.g. does not have a chain id associated with it).
-  private static final int REPLAY_UNPROTECTED_V_BASE = 27;
+  // The base of the signature v-value
+  private static final int V_BASE = 27;
 
   /**
    * Deserialize a transaction from RLP encoded bytes.
@@ -54,7 +53,7 @@ public final class Transaction {
     return RLP.decode(encoded, (reader) -> {
       Transaction tx = reader.readList(Transaction::readFrom);
       if (!reader.isComplete()) {
-        throw new InvalidRLPTypeException("Additional bytes present at the end of the encoded transaction");
+        throw new RLPException("Additional bytes present at the end of the encoded transaction");
       }
       return tx;
     });
@@ -76,32 +75,29 @@ public final class Transaction {
     try {
       address = addressBytes.isEmpty() ? null : Address.fromBytes(addressBytes);
     } catch (IllegalArgumentException e) {
-      throw new InvalidRLPTypeException("Value is the wrong size to be an address");
+      throw new RLPException("Value is the wrong size to be an address");
     }
     Wei value = Wei.valueOf(reader.readUInt256(false));
     Bytes payload = reader.readValue();
-    Bytes vbytes = reader.readValue();
-    if (vbytes.size() != 1) {
-      throw new InvalidRLPTypeException(
-          "The 'v' portion of the signature should be exactly 1 byte, it is " + vbytes.size() + " instead");
-    }
-    byte v = vbytes.get(0);
+    byte encodedV = reader.readByte();
     Bytes rbytes = reader.readValue();
     if (rbytes.size() > 32) {
-      throw new InvalidRLPTypeException(
-          "The length of the 'r' portion of the signature is " + rbytes.size() + ", it should be at most 32 bytes");
+      throw new RLPException("r-value of the signature is " + rbytes.size() + ", it should be at most 32 bytes");
     }
     BigInteger r = rbytes.toUnsignedBigInteger();
     Bytes sbytes = reader.readValue();
     if (sbytes.size() > 32) {
-      throw new InvalidRLPTypeException(
-          "The length of the 's' portion of the signature is " + sbytes.size() + ", it should be at most 32 bytes");
+      throw new RLPException("s-value of the signature is " + sbytes.size() + ", it should be at most 32 bytes");
     }
     BigInteger s = sbytes.toUnsignedBigInteger();
     if (!reader.isComplete()) {
-      throw new InvalidRLPTypeException("Additional bytes present at the end of the RLP transaction encoding");
+      throw new RLPException("Additional bytes present at the end of the RLP transaction encoding");
     }
-    return new Transaction(nonce, gasPrice, gasLimit, address, value, payload, Signature.create(r, s, v));
+
+    byte v = (byte) ((int) encodedV - V_BASE);
+
+    Signature signature = Signature.create(v, r, s);
+    return new Transaction(nonce, gasPrice, gasLimit, address, value, payload, signature);
   }
 
   private final UInt256 nonce;
@@ -134,7 +130,7 @@ public final class Transaction {
       Bytes payload,
       Signature signature) {
     requireNonNull(nonce);
-    checkArgument(nonce.compareTo(UInt256.ZERO) >= 0, "Nonce less than zero");
+    checkArgument(nonce.compareTo(UInt256.ZERO) >= 0, "nonce must be >= 0");
     requireNonNull(gasPrice);
     requireNonNull(value);
     requireNonNull(signature);
@@ -175,6 +171,13 @@ public final class Transaction {
   @Nullable
   public Address to() {
     return to;
+  }
+
+  /**
+   * @return <tt>true</tt> if the transaction is a contract creation (<tt>to</tt> address is <tt>null</tt>).
+   */
+  public boolean isContractCreation() {
+    return to == null;
   }
 
   /**
@@ -231,7 +234,7 @@ public final class Transaction {
       writer.writeValue(value.toMinimalBytes());
       writer.writeValue(payload);
     }), signature);
-    return Address.fromBytes(Hash.hash(publicKey.bytes()).toBytes().slice(12, 20));
+    return Address.fromBytes(Bytes.wrap(keccak256(publicKey.bytesArray()), 12, 20));
   }
 
   @Override
@@ -259,22 +262,15 @@ public final class Transaction {
 
   @Override
   public String toString() {
-    return "Transaction{"
-        + "nonce="
-        + nonce
-        + ", gasPrice="
-        + gasPrice
-        + ", gasLimit="
-        + gasLimit
-        + ", to="
-        + to
-        + ", value="
-        + value
-        + ", signature="
-        + signature
-        + ", payload="
-        + payload
-        + '}';
+    return String.format(
+        "Transaction{nonce=%s, gasPrice=%s, gasLimit=%s, to=%s, value=%s, signature=%s, payload=%s",
+        nonce,
+        gasPrice,
+        gasLimit,
+        to,
+        value,
+        signature,
+        payload);
   }
 
   /**
@@ -296,7 +292,7 @@ public final class Transaction {
     writer.writeValue((to != null) ? to.toBytes() : Bytes.EMPTY);
     writer.writeUInt256(value.toUInt256());
     writer.writeValue(payload);
-    writer.writeValue(Bytes.of(signature.v()));
+    writer.writeByte((byte) ((int) signature.v() + V_BASE));
     writer.writeBigInteger(signature.r());
     writer.writeBigInteger(signature.s());
   }

--- a/eth-domain/src/test/java/net/consensys/cava/eth/domain/BlockHeaderTest.java
+++ b/eth-domain/src/test/java/net/consensys/cava/eth/domain/BlockHeaderTest.java
@@ -12,7 +12,6 @@
  */
 package net.consensys.cava.eth.domain;
 
-import static net.consensys.cava.eth.domain.TransactionTest.randomBytes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.consensys.cava.bytes.Bytes;
@@ -31,21 +30,21 @@ class BlockHeaderTest {
 
   static BlockHeader generateBlockHeader() {
     return new BlockHeader(
-        Hash.fromBytes(randomBytes(32)),
-        Hash.fromBytes(randomBytes(32)),
+        Hash.fromBytes(Bytes.random(32)),
+        Hash.fromBytes(Bytes.random(32)),
         Address.fromBytes(Bytes.fromHexString("0x0102030405060708091011121314151617181920")),
-        Hash.fromBytes(randomBytes(32)),
-        Hash.fromBytes(randomBytes(32)),
-        Hash.fromBytes(randomBytes(32)),
-        randomBytes(8),
-        UInt256.fromBytes(randomBytes(32)),
-        UInt256.fromBytes(randomBytes(32)),
-        Gas.valueOf(UInt256.fromBytes(randomBytes(6))),
-        Gas.valueOf(UInt256.fromBytes(randomBytes(6))),
+        Hash.fromBytes(Bytes.random(32)),
+        Hash.fromBytes(Bytes.random(32)),
+        Hash.fromBytes(Bytes.random(32)),
+        Bytes.random(8),
+        UInt256.fromBytes(Bytes.random(32)),
+        UInt256.fromBytes(Bytes.random(32)),
+        Gas.valueOf(UInt256.fromBytes(Bytes.random(6))),
+        Gas.valueOf(UInt256.fromBytes(Bytes.random(6))),
         Instant.now().truncatedTo(ChronoUnit.SECONDS),
-        randomBytes(22),
-        Hash.fromBytes(randomBytes(32)),
-        randomBytes(8));
+        Bytes.random(22),
+        Hash.fromBytes(Bytes.random(32)),
+        Bytes.random(8));
   }
 
   @Test
@@ -54,5 +53,4 @@ class BlockHeaderTest {
     BlockHeader read = BlockHeader.fromBytes(blockHeader.toBytes());
     assertEquals(blockHeader, read);
   }
-
 }

--- a/eth-domain/src/test/java/net/consensys/cava/eth/domain/TransactionTest.java
+++ b/eth-domain/src/test/java/net/consensys/cava/eth/domain/TransactionTest.java
@@ -12,9 +12,11 @@
  */
 package net.consensys.cava.eth.domain;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.crypto.SECP256K1;
 import net.consensys.cava.crypto.SECP256K1.Signature;
 import net.consensys.cava.junit.BouncyCastleExtension;
 import net.consensys.cava.units.bigints.UInt256;
@@ -22,7 +24,6 @@ import net.consensys.cava.units.ethereum.Gas;
 import net.consensys.cava.units.ethereum.Wei;
 
 import java.math.BigInteger;
-import java.security.SecureRandom;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,14 +31,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(BouncyCastleExtension.class)
 class TransactionTest {
 
-  static Bytes randomBytes(int length) {
-    SecureRandom random = new SecureRandom();
-    byte[] bytes = new byte[length];
-    random.nextBytes(bytes);
-    return Bytes.wrap(bytes);
-  }
-
   static Transaction generateTransaction() {
+    Signature signature = SECP256K1.sign("random".getBytes(UTF_8), SECP256K1.KeyPair.random());
     return new Transaction(
         UInt256.valueOf(0),
         Wei.valueOf(BigInteger.valueOf(5L)),
@@ -45,7 +40,7 @@ class TransactionTest {
         Address.fromBytes(Bytes.fromHexString("0x0102030405060708091011121314151617181920")),
         Wei.valueOf(10L),
         Bytes.of(1, 2, 3, 4),
-        Signature.fromBytes(randomBytes(65)));
+        signature);
   }
 
   @Test

--- a/eth-reference-tests/src/test/java/net/consensys/cava/eth/reference/BlockRLPTestSuite.java
+++ b/eth-reference-tests/src/test/java/net/consensys/cava/eth/reference/BlockRLPTestSuite.java
@@ -64,17 +64,17 @@ class BlockRLPTestSuite {
       Block block,
       String rlp,
       String hash) {
-    Block rlpBlock = Block.fromBytes(Bytes.fromHexString(rlp));
+    Block rlpBlock = Block.fromHexString(rlp);
     assertEquals(block, rlpBlock);
     assertEquals(Bytes.fromHexString(rlp), block.toBytes());
-    assertEquals(Hash.fromBytes(Bytes.fromHexString(hash)), block.header().hash());
-    assertEquals(Hash.fromBytes(Bytes.fromHexString(hash)), rlpBlock.header().hash());
+    assertEquals(Hash.fromHexString(hash), block.header().hash());
+    assertEquals(Hash.fromHexString(hash), rlpBlock.header().hash());
   }
 
   private static Stream<Arguments> readBlockChainTests() throws IOException {
     URL testFolder = MerkleTrieTestSuite.class.getClassLoader().getResource("tests");
     if (testFolder == null) {
-      throw new RuntimeException("Tests folder missing. Please run git submodule --init");
+      throw new IllegalStateException("Tests folder missing. Please run git submodule --init");
     }
     Path folderPath = Paths.get(testFolder.getFile(), "BlockchainTests");
 
@@ -111,22 +111,22 @@ class BlockRLPTestSuite {
 
   @SuppressWarnings({"unchecked", "rawtypes"})
   private static BlockHeader createBlockHeader(Map headerData) {
-    checkNotNull(headerData, "" + headerData);
+    checkNotNull(headerData, headerData.toString());
     return new BlockHeader(
-        Hash.fromBytes(Bytes.fromHexString((String) headerData.get("parentHash"))),
-        Hash.fromBytes(Bytes.fromHexString((String) headerData.get("uncleHash"))),
-        Address.fromBytes(Bytes.fromHexString((String) headerData.get("coinbase"))),
-        Hash.fromBytes(Bytes.fromHexString((String) headerData.get("stateRoot"))),
-        Hash.fromBytes(Bytes.fromHexString((String) headerData.get("transactionsTrie"))),
-        Hash.fromBytes(Bytes.fromHexString((String) headerData.get("receiptTrie"))),
+        Hash.fromHexString((String) headerData.get("parentHash")),
+        Hash.fromHexString((String) headerData.get("uncleHash")),
+        Address.fromHexString((String) headerData.get("coinbase")),
+        Hash.fromHexString((String) headerData.get("stateRoot")),
+        Hash.fromHexString((String) headerData.get("transactionsTrie")),
+        Hash.fromHexString((String) headerData.get("receiptTrie")),
         Bytes.fromHexString((String) headerData.get("bloom")),
-        UInt256.fromBytes(Bytes.fromHexString((String) headerData.get("difficulty"))),
-        UInt256.fromBytes(Bytes.fromHexString((String) headerData.get("number"))),
-        Gas.valueOf(UInt256.fromBytes(Bytes.fromHexString((String) headerData.get("gasLimit")))),
-        Gas.valueOf(UInt256.fromBytes(Bytes.fromHexString((String) headerData.get("gasUsed")))),
+        UInt256.fromHexString((String) headerData.get("difficulty")),
+        UInt256.fromHexString((String) headerData.get("number")),
+        Gas.valueOf(UInt256.fromHexString((String) headerData.get("gasLimit"))),
+        Gas.valueOf(UInt256.fromHexString((String) headerData.get("gasUsed"))),
         Instant.ofEpochSecond(Bytes.fromHexString((String) headerData.get("timestamp")).toLong()),
         Bytes.fromHexString((String) headerData.get("extraData")),
-        Hash.fromBytes(Bytes.fromHexString((String) headerData.get("mixHash"))),
+        Hash.fromHexString((String) headerData.get("mixHash")),
         Bytes.fromHexString((String) headerData.get("nonce")));
   }
 
@@ -154,7 +154,7 @@ class BlockRLPTestSuite {
               Wei.valueOf(UInt256.fromHexString((String) txData.get("value"))),
               Bytes.fromHexString((String) txData.get("data")),
               Signature.create(
-                  Bytes.fromHexString((String) txData.get("v")).get(0),
+                  (byte) ((int) Bytes.fromHexString((String) txData.get("v")).get(0) - 27),
                   Bytes.fromHexString((String) txData.get("r")).toUnsignedBigInteger(),
                   Bytes.fromHexString((String) txData.get("s")).toUnsignedBigInteger())));
     }

--- a/rlp/src/main/java/net/consensys/cava/rlp/AccumulatingRLPWriter.java
+++ b/rlp/src/main/java/net/consensys/cava/rlp/AccumulatingRLPWriter.java
@@ -51,6 +51,11 @@ final class AccumulatingRLPWriter implements RLPWriter {
   }
 
   @Override
+  public void writeByte(byte value) {
+    encodeByteArray(new byte[] {value}, this::appendBytes);
+  }
+
+  @Override
   public void writeLong(long value) {
     appendBytes(encodeNumber(value));
   }

--- a/rlp/src/main/java/net/consensys/cava/rlp/ByteBufferRLPWriter.java
+++ b/rlp/src/main/java/net/consensys/cava/rlp/ByteBufferRLPWriter.java
@@ -48,6 +48,11 @@ final class ByteBufferRLPWriter implements RLPWriter {
   }
 
   @Override
+  public void writeByte(byte value) {
+    encodeByteArray(new byte[] {value}, buffer::put);
+  }
+
+  @Override
   public void writeLong(long value) {
     buffer.put(encodeNumber(value));
   }

--- a/rlp/src/main/java/net/consensys/cava/rlp/DelegatingRLPWriter.java
+++ b/rlp/src/main/java/net/consensys/cava/rlp/DelegatingRLPWriter.java
@@ -42,6 +42,11 @@ class DelegatingRLPWriter<T extends AccumulatingRLPWriter> implements RLPWriter 
   }
 
   @Override
+  public void writeByte(byte value) {
+    delegate.writeByte(value);
+  }
+
+  @Override
   public void writeInt(int value) {
     delegate.writeInt(value);
   }

--- a/rlp/src/main/java/net/consensys/cava/rlp/RLPReader.java
+++ b/rlp/src/main/java/net/consensys/cava/rlp/RLPReader.java
@@ -50,6 +50,21 @@ public interface RLPReader {
   }
 
   /**
+   * Read a byte from the RLP source.
+   *
+   * @return The byte for the next value.
+   * @throws InvalidRLPEncodingException If there is an error decoding the RLP source.
+   * @throws EndOfRLPException If there are no more RLP values to read.
+   */
+  default byte readByte() {
+    Bytes bytes = readValue();
+    if (bytes.size() != 1) {
+      throw new InvalidRLPTypeException("Value is not a single byte");
+    }
+    return bytes.get(0);
+  }
+
+  /**
    * Read an integer value from the RLP source.
    *
    * @return An integer.

--- a/rlp/src/main/java/net/consensys/cava/rlp/RLPWriter.java
+++ b/rlp/src/main/java/net/consensys/cava/rlp/RLPWriter.java
@@ -54,6 +54,15 @@ public interface RLPWriter {
   }
 
   /**
+   * Encode a byte to RLP.
+   *
+   * @param value The byte value to encode.
+   */
+  default void writeByte(byte value) {
+    writeValue(Bytes.of(value));
+  }
+
+  /**
    * Write an integer to the output.
    *
    * @param value The integer to write.

--- a/units/src/main/java/net/consensys/cava/units/bigints/UInt256.java
+++ b/units/src/main/java/net/consensys/cava/units/bigints/UInt256.java
@@ -110,13 +110,13 @@ public final class UInt256 implements UInt256Value<UInt256> {
   }
 
   /**
-   * Parse an hexadecimal string into a {@link UInt256}.
+   * Parse a hexadecimal string into a {@link UInt256}.
    *
    * @param str The hexadecimal string to parse, which may or may not start with "0x". That representation may contain
    *        less than 32 bytes, in which case the result is left padded with zeros.
    * @return The value corresponding to {@code str}.
-   * @throws IllegalArgumentException if {@code str} does not correspond to valid hexadecimal representation or contains
-   *         more than 32 bytes.
+   * @throws IllegalArgumentException if {@code str} does not correspond to a valid hexadecimal representation or
+   *         contains more than 32 bytes.
    */
   public static UInt256 fromHexString(String str) {
     return new UInt256(Bytes32.fromHexStringLenient(str));


### PR DESCRIPTION
Encodes recovery id using 0/1, rather than 27/28.

Also adds sign and verify methods that take a precomputed hash.