### PR TITLE
Correct the encoding of integer 0 in RLP

### DIFF
--- a/rlp/src/main/java/net/consensys/cava/rlp/RLP.java
+++ b/rlp/src/main/java/net/consensys/cava/rlp/RLP.java
@@ -169,6 +169,9 @@ public final class RLP {
   }
 
   static byte[] encodeNumber(long value) {
+    if (value == 0x00) {
+      return EMPTY_VALUE;
+    }
     if (value <= 0x7f) {
       return new byte[] {(byte) (value & 0xFF)};
     }

--- a/rlp/src/main/java/net/consensys/cava/rlp/RLPReader.java
+++ b/rlp/src/main/java/net/consensys/cava/rlp/RLPReader.java
@@ -62,7 +62,7 @@ public interface RLPReader {
     try {
       return bytes.intValue();
     } catch (IllegalArgumentException e) {
-      throw new InvalidRLPTypeException("Next value is too large to be represented as an int");
+      throw new InvalidRLPTypeException("Value is too large to be represented as an int");
     }
   }
 
@@ -79,7 +79,7 @@ public interface RLPReader {
     try {
       return bytes.longValue();
     } catch (IllegalArgumentException e) {
-      throw new InvalidRLPTypeException("Next value is too large to be represented as a long");
+      throw new InvalidRLPTypeException("Value is too large to be represented as a long");
     }
   }
 
@@ -96,7 +96,7 @@ public interface RLPReader {
     try {
       return UInt256.fromBytes(bytes);
     } catch (IllegalArgumentException e) {
-      throw new InvalidRLPTypeException("Next value is too large to be represented as a UInt256");
+      throw new InvalidRLPTypeException("Value is too large to be represented as a UInt256");
     }
   }
 

--- a/rlp/src/test/java/net/consensys/cava/rlp/BytesRLPWriterTest.java
+++ b/rlp/src/test/java/net/consensys/cava/rlp/BytesRLPWriterTest.java
@@ -59,17 +59,27 @@ class BytesRLPWriterTest {
 
   @Test
   void shouldWriteSmallIntegers() {
+    assertEquals(fromHexString("80"), RLP.encode(writer -> writer.writeInt(0)));
+    assertEquals(fromHexString("01"), RLP.encode(writer -> writer.writeInt(1)));
+    assertEquals(fromHexString("0f"), RLP.encode(writer -> writer.writeInt(15)));
     assertEquals(fromHexString("8203e8"), RLP.encode(writer -> writer.writeInt(1000)));
+    assertEquals(fromHexString("820400"), RLP.encode(writer -> writer.writeInt(1024)));
     assertEquals(fromHexString("830186a0"), RLP.encode(writer -> writer.writeInt(100000)));
   }
 
   @Test
   void shouldWriteLongIntegers() {
+    assertEquals(fromHexString("80"), RLP.encode(writer -> writer.writeLong(0L)));
+    assertEquals(fromHexString("01"), RLP.encode(writer -> writer.writeLong(1)));
+    assertEquals(fromHexString("0f"), RLP.encode(writer -> writer.writeLong(15)));
+    assertEquals(fromHexString("8203e8"), RLP.encode(writer -> writer.writeLong(1000)));
+    assertEquals(fromHexString("820400"), RLP.encode(writer -> writer.writeLong(1024)));
     assertEquals(fromHexString("830186a0"), RLP.encode(writer -> writer.writeLong(100000L)));
   }
 
   @Test
   void shouldWriteUInt256Integers() {
+    assertEquals(fromHexString("80"), RLP.encode(writer -> writer.writeUInt256(UInt256.valueOf(0L))));
     assertEquals(fromHexString("830186a0"), RLP.encode(writer -> writer.writeUInt256(UInt256.valueOf(100000L))));
     assertEquals(
         fromHexString("a00400000000000000000000000000000000000000000000000000f100000000ab"),


### PR DESCRIPTION
It was incorrectly being encoded as 0x00, rather than 0x80. It was decoding correctly, as 0x00 and 0x80 are (somewhat) equivalent.