### PR TITLE
Rename RLP#decodeList(..., BiConsumer) to decodeToList

### DIFF
--- a/eth-reference-tests/src/test/java/net/consensys/cava/eth/reference/RLPReferenceTestSuite.java
+++ b/eth-reference-tests/src/test/java/net/consensys/cava/eth/reference/RLPReferenceTestSuite.java
@@ -98,7 +98,7 @@ class RLPReferenceTestSuite {
   void testReadInvalidRLP(String name, Object in, String out) {
     assertThrows(RLPException.class, () -> {
       if ("incorrectLengthInArray".equals(name)) {
-        RLP.decodeList(Bytes.fromHexString(out), (reader, list) -> {
+        RLP.decodeToList(Bytes.fromHexString(out), (reader, list) -> {
         });
       } else {
         RLP.decodeValue(Bytes.fromHexString(out));

--- a/rlp/src/main/java/net/consensys/cava/rlp/RLP.java
+++ b/rlp/src/main/java/net/consensys/cava/rlp/RLP.java
@@ -296,8 +296,8 @@ public final class RLP {
    * @throws InvalidRLPEncodingException If there is an error decoding the RLP source.
    * @throws InvalidRLPTypeException If the first RLP value is not a list.
    */
-  public static List<Object> decodeList(Bytes source, BiConsumer<RLPReader, List<Object>> fn) {
-    return decodeList(source, false, fn);
+  public static List<Object> decodeToList(Bytes source, BiConsumer<RLPReader, List<Object>> fn) {
+    return decodeToList(source, false, fn);
   }
 
   /**
@@ -310,7 +310,7 @@ public final class RLP {
    * @throws InvalidRLPEncodingException If there is an error decoding the RLP source.
    * @throws InvalidRLPTypeException If the first RLP value is not a list.
    */
-  public static List<Object> decodeList(Bytes source, boolean lenient, BiConsumer<RLPReader, List<Object>> fn) {
+  public static List<Object> decodeToList(Bytes source, boolean lenient, BiConsumer<RLPReader, List<Object>> fn) {
     requireNonNull(source);
     requireNonNull(fn);
     checkArgument(source.size() > 0, "source is empty");

--- a/rlp/src/main/java/net/consensys/cava/rlp/RLPReader.java
+++ b/rlp/src/main/java/net/consensys/cava/rlp/RLPReader.java
@@ -336,7 +336,18 @@ public interface RLPReader {
    * @throws InvalidRLPEncodingException If there is an error decoding the RLP source.
    * @throws EndOfRLPException If there are no more RLP values to read.
    */
-  void skipNext();
+  default void skipNext() {
+    skipNext(isLenient());
+  }
+
+  /**
+   * Skip the next value or list in the RLP source.
+   *
+   * @param lenient If <tt>false</tt>, an exception will be thrown if the integer is not minimally encoded.
+   * @throws InvalidRLPEncodingException If there is an error decoding the RLP source.
+   * @throws EndOfRLPException If there are no more RLP values to read.
+   */
+  void skipNext(boolean lenient);
 
   /**
    * The number of remaining values to read.


### PR DESCRIPTION
Removes the generics overload on the method name.

Also, add leniency to RLPReader#skip and do stricter checking of list encoding.