### PR TITLE
Make nullable references volatile

### DIFF
--- a/merkle-trie/src/main/kotlin/net/consensys/cava/trie/experimental/BranchNode.kt
+++ b/merkle-trie/src/main/kotlin/net/consensys/cava/trie/experimental/BranchNode.kt
@@ -34,7 +34,9 @@ internal class BranchNode<V>(
     const val RADIX = CompactEncoding.LEAF_TERMINATOR.toInt()
   }
 
+  @Volatile
   private var rlp: WeakReference<Bytes>? = null
+  @Volatile
   private var hash: SoftReference<Bytes32>? = null
 
   init {

--- a/merkle-trie/src/main/kotlin/net/consensys/cava/trie/experimental/ExtensionNode.kt
+++ b/merkle-trie/src/main/kotlin/net/consensys/cava/trie/experimental/ExtensionNode.kt
@@ -25,7 +25,9 @@ internal class ExtensionNode<V>(
   private val child: Node<V>,
   private val nodeFactory: NodeFactory<V>
 ) : Node<V> {
+  @Volatile
   private var rlp: WeakReference<Bytes>? = null
+  @Volatile
   private var hash: SoftReference<Bytes32>? = null
 
   init {

--- a/merkle-trie/src/main/kotlin/net/consensys/cava/trie/experimental/LeafNode.kt
+++ b/merkle-trie/src/main/kotlin/net/consensys/cava/trie/experimental/LeafNode.kt
@@ -26,7 +26,9 @@ internal class LeafNode<V>(
   private val nodeFactory: NodeFactory<V>,
   private val valueSerializer: (V) -> Bytes
 ) : Node<V> {
+  @Volatile
   private var rlp: WeakReference<Bytes>? = null
+  @Volatile
   private var hash: SoftReference<Bytes32>? = null
 
   override suspend fun accept(visitor: NodeVisitor<V>, path: Bytes): Node<V> = visitor.visit(this, path)

--- a/merkle-trie/src/main/kotlin/net/consensys/cava/trie/experimental/StoredNode.kt
+++ b/merkle-trie/src/main/kotlin/net/consensys/cava/trie/experimental/StoredNode.kt
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference
 internal class StoredNode<V> : Node<V> {
   private val nodeFactory: StoredNodeFactory<V>
   private val hash: Bytes32
+  @Volatile
   private var loaded: SoftReference<Node<V>>? = null
   private val loader = AtomicReference<Deferred<Node<V>>>()
 


### PR DESCRIPTION
Avoids unnecessary recalculation that might occur if the null reference was cached overly long.