### PR TITLE
Add RocksDB support to KVs

### DIFF
--- a/dependency-versions.gradle
+++ b/dependency-versions.gradle
@@ -47,6 +47,7 @@ dependencyManagement {
       entry 'logl-logl'
     }
     dependency('org.mapdb:mapdb:3.0.7')
+    dependency('org.rocksdb:rocksdbjni:5.17.2')
     dependency('org.xerial.snappy:snappy-java:1.1.7.2')
   }
 }

--- a/gradle/check-licenses.gradle
+++ b/gradle/check-licenses.gradle
@@ -118,7 +118,7 @@ downloadLicenses {
 
   licenses = [
     (group('cava')): apache2,
-
+    (group('org.rocksdb')): apache2,
     // https://checkerframework.org/manual/#license
     // The more permissive MIT License applies to code that you might want
     // to include in your own program, such as the annotations and run-time utility classes.

--- a/kv/build.gradle
+++ b/kv/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   compileOnly 'com.jolbox:bonecp'
   compileOnly 'io.lettuce:lettuce-core'
   compileOnly 'org.fusesource.leveldbjni:leveldbjni-all'
+  compileOnly 'org.rocksdb:rocksdbjni'
   compileOnly 'org.mapdb:mapdb'
 
   testCompile project(':concurrent')
@@ -24,6 +25,7 @@ dependencies {
   testCompile 'org.junit.jupiter:junit-jupiter-api'
   testCompile 'org.junit.jupiter:junit-jupiter-params'
   testCompile 'org.mapdb:mapdb'
+  testCompile 'org.rocksdb:rocksdbjni'
 
   testRuntime 'org.jetbrains.spek:spek-junit-platform-engine'
   testRuntime 'org.junit.jupiter:junit-jupiter-engine'

--- a/kv/src/main/kotlin/net/consensys/cava/kv/RocksDBKeyValueStore.kt
+++ b/kv/src/main/kotlin/net/consensys/cava/kv/RocksDBKeyValueStore.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.kv
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import net.consensys.cava.bytes.Bytes
+import org.rocksdb.Options
+import org.rocksdb.RocksDB
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * A key-value store backed by RocksDB.
+ *
+ * @param dbPath The path to the RocksDB database.
+ * @param options Options for the RocksDB database.
+ * @param dispatcher The co-routine context for blocking tasks.
+ * @return A key-value store.
+ * @throws IOException If an I/O error occurs.
+ * @constructor Open a RocksDB-backed key-value store.
+ */
+class RocksDBKeyValueStore
+@Throws(IOException::class)
+constructor(
+  dbPath: Path,
+  options: Options = Options().setCreateIfMissing(true).setWriteBufferSize(268435456).setMaxOpenFiles(-1),
+  private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+) : KeyValueStore {
+
+  companion object {
+    /**
+     * Open a RocksDB-backed key-value store.
+     *
+     * @param dbPath The path to the RocksDB database.
+     * @return A key-value store.
+     * @throws IOException If an I/O error occurs.
+     */
+    @JvmStatic
+    @Throws(IOException::class)
+    fun open(dbPath: Path) = RocksDBKeyValueStore(dbPath)
+
+    /**
+     * Open a RocksDB-backed key-value store.
+     *
+     * @param dbPath The path to the RocksDB database.
+     * @param options Options for the RocksDB database.
+     * @return A key-value store.
+     * @throws IOException If an I/O error occurs.
+     */
+    @JvmStatic
+    @Throws(IOException::class)
+    fun open(dbPath: Path, options: Options) = RocksDBKeyValueStore(dbPath, options)
+  }
+
+  private val db: RocksDB
+  private val closed = AtomicBoolean(false)
+
+  init {
+    RocksDB.loadLibrary()
+    Files.createDirectories(dbPath)
+    db = RocksDB.open(options, dbPath.toAbsolutePath().toString())
+  }
+
+  override suspend fun get(key: Bytes): Bytes? = withContext(dispatcher) {
+    if (closed.get()) {
+      throw IllegalStateException("Closed DB")
+    }
+    val rawValue = db[key.toArrayUnsafe()]
+    if (rawValue == null) {
+      null
+    } else {
+      Bytes.wrap(rawValue)
+    }
+  }
+
+  override suspend fun put(key: Bytes, value: Bytes) = withContext(dispatcher) {
+    if (closed.get()) {
+      throw IllegalStateException("Closed DB")
+    }
+    db.put(key.toArrayUnsafe(), value.toArrayUnsafe())
+  }
+
+  /**
+   * Closes the underlying RocksDB instance.
+   */
+  override fun close() {
+    if (closed.compareAndSet(false, true)) {
+      db.close()
+    }
+  }
+}

--- a/kv/src/test/java/net/consensys/cava/kv/KeyValueStoreTest.java
+++ b/kv/src/test/java/net/consensys/cava/kv/KeyValueStoreTest.java
@@ -60,4 +60,15 @@ class KeyValueStoreTest {
       assertEquals(Bytes.of(10, 12, 13), value);
     }
   }
+
+  @Test
+  void testRocksDBWithoutOptions(@TempDirectory Path tempDirectory) throws Exception {
+    try (RocksDBKeyValueStore rocksdb = RocksDBKeyValueStore.open(tempDirectory.resolve("foo").resolve("bar"))) {
+      AsyncCompletion completion = rocksdb.putAsync(Bytes.of(123), Bytes.of(10, 12, 13));
+      completion.join();
+      Bytes value = rocksdb.getAsync(Bytes.of(123)).get();
+      assertNotNull(value);
+      assertEquals(Bytes.of(10, 12, 13), value);
+    }
+  }
 }


### PR DESCRIPTION
Also have KVs implement their own CoroutineScope, similar to DiscoveryService, so we don't use GlobalScope in async methods.