### PR TITLE
Add bounded types to SSZWriter methods which support java.util.List.

### DIFF
--- a/ssz/src/main/java/net/consensys/cava/ssz/SSZ.java
+++ b/ssz/src/main/java/net/consensys/cava/ssz/SSZ.java
@@ -477,7 +477,7 @@ public final class SSZ {
    * @param elements The bytes to write as a java.util.List.
    * @return SSZ encoding in a {@link Bytes} value.
    */
-  public static Bytes encodeBytesList(List<Bytes> elements) {
+  public static Bytes encodeBytesList(List<? extends Bytes> elements) {
     ArrayList<Bytes> encoded = new ArrayList<>(elements.size() * 2 + 1);
     encodeBytesListTo(elements, encoded::add);
     return Bytes.wrap(encoded.toArray(new Bytes[0]));
@@ -500,7 +500,7 @@ public final class SSZ {
     }
   }
 
-  static void encodeBytesListTo(List<Bytes> elements, Consumer<Bytes> appender) {
+  static void encodeBytesListTo(List<? extends Bytes> elements, Consumer<Bytes> appender) {
     // pre-calculate the list size - relies on knowing how encodeBytesTo does its serialization, but is worth it
     // to avoid having to pre-serialize all the elements
     long listSize = 0;
@@ -913,7 +913,7 @@ public final class SSZ {
    * @param elements The java.util.List of hashes to write.
    * @return SSZ encoding in a {@link Bytes} value.
    */
-  public static Bytes encodeHashList(List<Bytes> elements) {
+  public static Bytes encodeHashList(List<? extends Bytes> elements) {
     ArrayList<Bytes> encoded = new ArrayList<>(elements.size() + 1);
     encodeHashListTo(elements, b -> encoded.add(Bytes.wrap(b)));
     return Bytes.wrap(encoded.toArray(new Bytes[0]));
@@ -934,7 +934,7 @@ public final class SSZ {
     }
   }
 
-  static void encodeHashListTo(List<Bytes> elements, Consumer<Bytes> appender) {
+  static void encodeHashListTo(List<? extends Bytes> elements, Consumer<Bytes> appender) {
     int hashLength = 0;
     for (Bytes bytes : elements) {
       if (hashLength == 0) {
@@ -969,7 +969,7 @@ public final class SSZ {
    * @return SSZ encoding in a {@link Bytes} value.
    * @throws IllegalArgumentException If any {@code address.size != 20}.
    */
-  public static Bytes encodeAddressList(List<Bytes> elements) {
+  public static Bytes encodeAddressList(List<? extends Bytes> elements) {
     ArrayList<Bytes> encoded = new ArrayList<>(elements.size() + 1);
     encodeAddressListTo(elements, b -> encoded.add(Bytes.wrap(b)));
     return Bytes.wrap(encoded.toArray(new Bytes[0]));
@@ -982,7 +982,7 @@ public final class SSZ {
     }
   }
 
-  static void encodeAddressListTo(List<Bytes> elements, Consumer<Bytes> appender) {
+  static void encodeAddressListTo(List<? extends Bytes> elements, Consumer<Bytes> appender) {
     appender.accept(Bytes.wrap(listLengthPrefix(elements.size(), 20)));
     for (Bytes bytes : elements) {
       appender.accept(encodeAddress(bytes));

--- a/ssz/src/main/java/net/consensys/cava/ssz/SSZWriter.java
+++ b/ssz/src/main/java/net/consensys/cava/ssz/SSZWriter.java
@@ -254,7 +254,7 @@ public interface SSZWriter {
    *
    * @param elements The bytes to write as a java.util.List.
    */
-  default void writeBytesList(List<Bytes> elements) {
+  default void writeBytesList(List<? extends Bytes> elements) {
     SSZ.encodeBytesListTo(elements, this::writeSSZ);
   }
 
@@ -498,7 +498,7 @@ public interface SSZWriter {
    *
    * @param elements The java.util.List of Bytes (hash) elements to write.
    */
-  default void writeHashList(List<Bytes> elements) {
+  default void writeHashList(List<? extends Bytes> elements) {
     SSZ.encodeHashListTo(elements, this::writeSSZ);
   }
 
@@ -518,7 +518,7 @@ public interface SSZWriter {
    * @param elements The java.util.List of Bytes (address) elements to write.
    * @throws IllegalArgumentException If any {@code address.size != 20}.
    */
-  default void writeAddressList(List<Bytes> elements) {
+  default void writeAddressList(List<? extends Bytes> elements) {
     SSZ.encodeAddressListTo(elements, this::writeSSZ);
   }
 

--- a/ssz/src/test/java/net/consensys/cava/ssz/BytesSSZWriterTest.java
+++ b/ssz/src/test/java/net/consensys/cava/ssz/BytesSSZWriterTest.java
@@ -354,6 +354,18 @@ class BytesSSZWriterTest {
   }
 
   @Test
+  void shouldWriteUtilListOfExtendedBytesType() {
+    assertEquals(
+        fromHexString(
+            "0x6C000000200000000000000000000000000000000000000000000000000000000000000000626F6220000000000000000000000000000000000000000000000000000000000000006A616E65200000000000000000000000000000000000000000000000000000000000006A616E6574"),
+        SSZ.encodeBytesList(
+            Arrays.asList(
+                Bytes32.leftPad(Bytes.wrap("bob".getBytes(Charsets.UTF_8))),
+                Bytes32.leftPad(Bytes.wrap("jane".getBytes(Charsets.UTF_8))),
+                Bytes32.leftPad(Bytes.wrap("janet".getBytes(Charsets.UTF_8))))));
+  }
+
+  @Test
   void shouldWriteVaragsListsOfHashes() {
     assertEquals(
         fromHexString(


### PR DESCRIPTION
Often, Bytes is not used directly, but is used in the form of one of the types which extends/implements Bytes i.e. Bytes32 and Bytes48. Adding bounded types to SSZWriter and SSZ allows these types to be serialized as well.