### PR TITLE
Add support for Sodium HMAC methods

### DIFF
--- a/crypto/src/main/java/net/consensys/cava/crypto/sodium/HMACSHA256.java
+++ b/crypto/src/main/java/net/consensys/cava/crypto/sodium/HMACSHA256.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.crypto.sodium;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import net.consensys.cava.bytes.Bytes;
+
+import javax.annotation.Nullable;
+import javax.security.auth.Destroyable;
+
+import jnr.ffi.Pointer;
+
+/**
+ * Message authentication code support for HMAC-SHA-256.
+ */
+public final class HMACSHA256 {
+
+  private HMACSHA256() {}
+
+  /**
+   * A HMACSHA256 secret key.
+   */
+  public static final class Key implements Destroyable {
+    @Nullable
+    private Pointer ptr;
+    private final int length;
+
+    private Key(Pointer ptr, int length) {
+      this.ptr = ptr;
+      this.length = length;
+    }
+
+    @Override
+    protected void finalize() {
+      destroy();
+    }
+
+    @Override
+    public void destroy() {
+      if (ptr != null) {
+        Pointer p = ptr;
+        ptr = null;
+        Sodium.sodium_free(p);
+      }
+    }
+
+    @Override
+    public boolean isDestroyed() {
+      return ptr == null;
+    }
+
+    /**
+     * Create a {@link Key} from an array of bytes.
+     *
+     * <p>
+     * The byte array must be of length {@link #length()}.
+     *
+     * @param bytes The bytes for the secret key.
+     * @return A secret key.
+     */
+    public static Key fromBytes(Bytes bytes) {
+      return fromBytes(bytes.toArrayUnsafe());
+    }
+
+    /**
+     * Create a {@link Key} from an array of bytes.
+     *
+     * <p>
+     * The byte array must be of length {@link #length()}.
+     *
+     * @param bytes The bytes for the secret key.
+     * @return A secret key.
+     */
+    public static Key fromBytes(byte[] bytes) {
+      if (bytes.length != Sodium.crypto_auth_hmacsha256_keybytes()) {
+        throw new IllegalArgumentException(
+            "key must be " + Sodium.crypto_auth_hmacsha256_keybytes() + " bytes, got " + bytes.length);
+      }
+      return Sodium.dup(bytes, Key::new);
+    }
+
+    /**
+     * Generate a random {@link Key}.
+     *
+     * @return A randomly generated secret key.
+     */
+    public static Key random() {
+      return Sodium.randomBytes(length(), Key::new);
+    }
+
+    /**
+     * Obtain the length of the key in bytes (32).
+     *
+     * @return The length of the key in bytes (32).
+     */
+    public static int length() {
+      long keybytes = Sodium.crypto_auth_hmacsha256_keybytes();
+      if (keybytes > Integer.MAX_VALUE) {
+        throw new SodiumException("crypto_auth_hmacsha256_keybytes: " + keybytes + " is too large");
+      }
+      return (int) keybytes;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj instanceof Key)) {
+        return false;
+      }
+      checkState(ptr != null, "Key has been destroyed");
+      Key other = (Key) obj;
+      return other.ptr != null && Sodium.sodium_memcmp(this.ptr, other.ptr, length) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+      checkState(ptr != null, "Key has been destroyed");
+      return Sodium.hashCode(ptr, length);
+    }
+
+    /**
+     * @return The bytes of this key.
+     */
+    public Bytes bytes() {
+      return Bytes.wrap(bytesArray());
+    }
+
+    /**
+     * @return The bytes of this key.
+     */
+    public byte[] bytesArray() {
+      checkState(ptr != null, "Key has been destroyed");
+      return Sodium.reify(ptr, length);
+    }
+  }
+
+  /**
+   * Authenticates a message using a secret into a HMAC-SHA-256 authenticator.
+   *
+   * @param message the message to authenticate
+   * @param key the secret key to use for authentication
+   * @return the authenticator of the message
+   */
+  public static Bytes authenticate(Bytes message, Key key) {
+    return Bytes.wrap(authenticate(message.toArrayUnsafe(), key));
+  }
+
+  /**
+   * Authenticates a message using a secret into a HMAC-SHA-256 authenticator.
+   *
+   * @param message the message to authenticate
+   * @param key the secret key to use for authentication
+   * @return the authenticator of the message
+   */
+  public static byte[] authenticate(byte[] message, Key key) {
+    checkArgument(key.ptr != null, "Key has been destroyed");
+    long authBytes = Sodium.crypto_auth_hmacsha256_bytes();
+    if (authBytes > Integer.MAX_VALUE) {
+      throw new SodiumException("crypto_auth_hmacsha256_bytes: " + authBytes + " is too large");
+    }
+    byte[] out = new byte[(int) authBytes];
+    int rc = Sodium.crypto_auth_hmacsha256(out, message, message.length, key.ptr);
+    if (rc != 0) {
+      throw new SodiumException("crypto_auth_hmacsha256: failed with result " + rc);
+    }
+    return out;
+  }
+
+  /**
+   * Verifies the authenticator of a message matches according to a secret.
+   *
+   * @param authenticator the authenticator to verify
+   * @param in the message to match against the authenticator
+   * @param key the secret key to use for verification
+   * @return true if the authenticator verifies the message according to the secret, false otherwise
+   */
+  public static boolean verify(Bytes authenticator, Bytes in, Key key) {
+    return verify(authenticator.toArrayUnsafe(), in.toArrayUnsafe(), key);
+  }
+
+  /**
+   * Verifies the authenticator of a message matches according to a secret.
+   *
+   * @param authenticator the authenticator to verify
+   * @param in the message to match against the authenticator
+   * @param key the secret key to use for verification
+   * @return true if the authenticator verifies the message according to the secret, false otherwise
+   */
+  public static boolean verify(byte[] authenticator, byte[] in, Key key) {
+    checkArgument(key.ptr != null, "Key has been destroyed");
+    if (authenticator.length != Sodium.crypto_auth_hmacsha256_bytes()) {
+      throw new IllegalArgumentException(
+          "Expected authenticator of "
+              + Sodium.crypto_auth_hmacsha256_bytes()
+              + " bytes, got "
+              + authenticator.length
+              + " instead");
+    }
+    int rc = Sodium.crypto_auth_hmacsha256_verify(authenticator, in, in.length, key.ptr);
+    return rc == 0;
+  }
+}

--- a/crypto/src/main/java/net/consensys/cava/crypto/sodium/HMACSHA512.java
+++ b/crypto/src/main/java/net/consensys/cava/crypto/sodium/HMACSHA512.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.crypto.sodium;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import net.consensys.cava.bytes.Bytes;
+
+import javax.annotation.Nullable;
+import javax.security.auth.Destroyable;
+
+import jnr.ffi.Pointer;
+
+/**
+ * Message authentication code support for HMAC-SHA-512.
+ */
+public final class HMACSHA512 {
+
+  private HMACSHA512() {}
+
+  /**
+   * A HMACSHA512 secret key.
+   */
+  public static final class Key implements Destroyable {
+    @Nullable
+    private Pointer ptr;
+    private final int length;
+
+    private Key(Pointer ptr, int length) {
+      this.ptr = ptr;
+      this.length = length;
+    }
+
+    @Override
+    protected void finalize() {
+      destroy();
+    }
+
+    @Override
+    public void destroy() {
+      if (ptr != null) {
+        Pointer p = ptr;
+        ptr = null;
+        Sodium.sodium_free(p);
+      }
+    }
+
+    @Override
+    public boolean isDestroyed() {
+      return ptr == null;
+    }
+
+    /**
+     * Create a {@link Key} from an array of bytes.
+     *
+     * <p>
+     * The byte array must be of length {@link #length()}.
+     *
+     * @param bytes The bytes for the secret key.
+     * @return A secret key.
+     */
+    public static Key fromBytes(Bytes bytes) {
+      return fromBytes(bytes.toArrayUnsafe());
+    }
+
+    /**
+     * Create a {@link Key} from an array of bytes.
+     *
+     * <p>
+     * The byte array must be of length {@link #length()}.
+     *
+     * @param bytes The bytes for the secret key.
+     * @return A secret key.
+     */
+    public static Key fromBytes(byte[] bytes) {
+      if (bytes.length != Sodium.crypto_auth_hmacsha512_keybytes()) {
+        throw new IllegalArgumentException(
+            "key must be " + Sodium.crypto_auth_hmacsha512_keybytes() + " bytes, got " + bytes.length);
+      }
+      return Sodium.dup(bytes, Key::new);
+    }
+
+    /**
+     * Generate a random {@link Key}.
+     *
+     * @return A randomly generated secret key.
+     */
+    public static Key random() {
+      return Sodium.randomBytes(length(), Key::new);
+    }
+
+    /**
+     * Obtain the length of the key in bytes (32).
+     *
+     * @return The length of the key in bytes (32).
+     */
+    public static int length() {
+      long keybytes = Sodium.crypto_auth_hmacsha512_keybytes();
+      if (keybytes > Integer.MAX_VALUE) {
+        throw new SodiumException("crypto_auth_hmacsha512_keybytes: " + keybytes + " is too large");
+      }
+      return (int) keybytes;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj instanceof Key)) {
+        return false;
+      }
+      checkState(ptr != null, "Key has been destroyed");
+      Key other = (Key) obj;
+      return other.ptr != null && Sodium.sodium_memcmp(this.ptr, other.ptr, length) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+      checkState(ptr != null, "Key has been destroyed");
+      return Sodium.hashCode(ptr, length);
+    }
+
+    /**
+     * @return The bytes of this key.
+     */
+    public Bytes bytes() {
+      return Bytes.wrap(bytesArray());
+    }
+
+    /**
+     * @return The bytes of this key.
+     */
+    public byte[] bytesArray() {
+      checkState(ptr != null, "Key has been destroyed");
+      return Sodium.reify(ptr, length);
+    }
+  }
+
+  /**
+   * Authenticates a message using a secret into a HMAC-SHA-512 authenticator.
+   *
+   * @param message the message to authenticate
+   * @param key the secret key to use for authentication
+   * @return the authenticator of the message
+   */
+  public static Bytes authenticate(Bytes message, Key key) {
+    return Bytes.wrap(authenticate(message.toArrayUnsafe(), key));
+  }
+
+  /**
+   * Authenticates a message using a secret into a HMAC-SHA-512 authenticator.
+   *
+   * @param message the message to authenticate
+   * @param key the secret key to use for authentication
+   * @return the authenticator of the message
+   */
+  public static byte[] authenticate(byte[] message, Key key) {
+    checkArgument(key.ptr != null, "Key has been destroyed");
+    long authBytes = Sodium.crypto_auth_hmacsha512_bytes();
+    if (authBytes > Integer.MAX_VALUE) {
+      throw new SodiumException("crypto_auth_hmacsha512_bytes: " + authBytes + " is too large");
+    }
+    byte[] out = new byte[(int) authBytes];
+    int rc = Sodium.crypto_auth_hmacsha512(out, message, message.length, key.ptr);
+    if (rc != 0) {
+      throw new SodiumException("crypto_auth_hmacsha512: failed with result " + rc);
+    }
+    return out;
+  }
+
+  /**
+   * Verifies the authenticator of a message matches according to a secret.
+   *
+   * @param authenticator the authenticator to verify
+   * @param in the message to match against the authenticator
+   * @param key the secret key to use for verification
+   * @return true if the authenticator verifies the message according to the secret, false otherwise
+   */
+  public static boolean verify(Bytes authenticator, Bytes in, Key key) {
+    return verify(authenticator.toArrayUnsafe(), in.toArrayUnsafe(), key);
+  }
+
+  /**
+   * Verifies the authenticator of a message matches according to a secret.
+   *
+   * @param authenticator the authenticator to verify
+   * @param in the message to match against the authenticator
+   * @param key the secret key to use for verification
+   * @return true if the authenticator verifies the message according to the secret, false otherwise
+   */
+  public static boolean verify(byte[] authenticator, byte[] in, Key key) {
+    checkArgument(key.ptr != null, "Key has been destroyed");
+    if (authenticator.length != Sodium.crypto_auth_hmacsha512_bytes()) {
+      throw new IllegalArgumentException(
+          "Expected authenticator of "
+              + Sodium.crypto_auth_hmacsha512_bytes()
+              + " bytes, got "
+              + authenticator.length
+              + " instead");
+    }
+    int rc = Sodium.crypto_auth_hmacsha512_verify(authenticator, in, in.length, key.ptr);
+    return rc == 0;
+  }
+}

--- a/crypto/src/main/java/net/consensys/cava/crypto/sodium/HMACSHA512256.java
+++ b/crypto/src/main/java/net/consensys/cava/crypto/sodium/HMACSHA512256.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.crypto.sodium;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import net.consensys.cava.bytes.Bytes;
+
+import javax.annotation.Nullable;
+import javax.security.auth.Destroyable;
+
+import jnr.ffi.Pointer;
+
+/**
+ * Message authentication code support for HMAC-SHA-512-256.
+ * <p>
+ * HMAC-SHA-512-256 is implemented as HMAC-SHA-512 with the output truncated to 256 bits. This is slightly faster than
+ * HMAC-SHA-256. Note that this construction is not the same as HMAC-SHA-512/256, which is HMAC using the SHA-512/256
+ * function.
+ */
+public final class HMACSHA512256 {
+
+  private HMACSHA512256() {}
+
+  /**
+   * A HMACSHA512256 secret key.
+   */
+  public static final class Key implements Destroyable {
+    @Nullable
+    private Pointer ptr;
+    private final int length;
+
+    private Key(Pointer ptr, int length) {
+      this.ptr = ptr;
+      this.length = length;
+    }
+
+    @Override
+    protected void finalize() {
+      destroy();
+    }
+
+    @Override
+    public void destroy() {
+      if (ptr != null) {
+        Pointer p = ptr;
+        ptr = null;
+        Sodium.sodium_free(p);
+      }
+    }
+
+    @Override
+    public boolean isDestroyed() {
+      return ptr == null;
+    }
+
+    /**
+     * Create a {@link Key} from an array of bytes.
+     *
+     * <p>
+     * The byte array must be of length {@link #length()}.
+     *
+     * @param bytes The bytes for the secret key.
+     * @return A secret key.
+     */
+    public static Key fromBytes(Bytes bytes) {
+      return fromBytes(bytes.toArrayUnsafe());
+    }
+
+    /**
+     * Create a {@link Key} from an array of bytes.
+     *
+     * <p>
+     * The byte array must be of length {@link #length()}.
+     *
+     * @param bytes The bytes for the secret key.
+     * @return A secret key.
+     */
+    public static Key fromBytes(byte[] bytes) {
+      if (bytes.length != Sodium.crypto_auth_hmacsha512256_keybytes()) {
+        throw new IllegalArgumentException(
+            "key must be " + Sodium.crypto_auth_hmacsha512256_keybytes() + " bytes, got " + bytes.length);
+      }
+      return Sodium.dup(bytes, Key::new);
+    }
+
+    /**
+     * Generate a random {@link Key}.
+     *
+     * @return A randomly generated secret key.
+     */
+    public static Key random() {
+      return Sodium.randomBytes(length(), Key::new);
+    }
+
+    /**
+     * Obtain the length of the key in bytes (32).
+     *
+     * @return The length of the key in bytes (32).
+     */
+    public static int length() {
+      long keybytes = Sodium.crypto_auth_hmacsha512256_keybytes();
+      if (keybytes > Integer.MAX_VALUE) {
+        throw new SodiumException("crypto_auth_hmacsha512256_keybytes: " + keybytes + " is too large");
+      }
+      return (int) keybytes;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj instanceof Key)) {
+        return false;
+      }
+      checkState(ptr != null, "Key has been destroyed");
+      Key other = (Key) obj;
+      return other.ptr != null && Sodium.sodium_memcmp(this.ptr, other.ptr, length) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+      checkState(ptr != null, "Key has been destroyed");
+      return Sodium.hashCode(ptr, length);
+    }
+
+    /**
+     * @return The bytes of this key.
+     */
+    public Bytes bytes() {
+      return Bytes.wrap(bytesArray());
+    }
+
+    /**
+     * @return The bytes of this key.
+     */
+    public byte[] bytesArray() {
+      checkState(ptr != null, "Key has been destroyed");
+      return Sodium.reify(ptr, length);
+    }
+  }
+
+  /**
+   * Authenticates a message using a secret into a HMAC-SHA-512-256 authenticator.
+   *
+   * @param message the message to authenticate
+   * @param key the secret key to use for authentication
+   * @return the authenticator of the message
+   */
+  public static Bytes authenticate(Bytes message, Key key) {
+    return Bytes.wrap(authenticate(message.toArrayUnsafe(), key));
+  }
+
+  /**
+   * Authenticates a message using a secret into a HMAC-SHA-512-256 authenticator.
+   *
+   * @param message the message to authenticate
+   * @param key the secret key to use for authentication
+   * @return the authenticator of the message
+   */
+  public static byte[] authenticate(byte[] message, Key key) {
+    checkArgument(key.ptr != null, "Key has been destroyed");
+    long authBytes = Sodium.crypto_auth_hmacsha512256_bytes();
+    if (authBytes > Integer.MAX_VALUE) {
+      throw new SodiumException("crypto_auth_hmacsha512256_bytes: " + authBytes + " is too large");
+    }
+    byte[] out = new byte[(int) authBytes];
+    int rc = Sodium.crypto_auth_hmacsha512256(out, message, message.length, key.ptr);
+    if (rc != 0) {
+      throw new SodiumException("crypto_auth_hmacsha512256: failed with result " + rc);
+    }
+    return out;
+  }
+
+  /**
+   * Verifies the authenticator of a message matches according to a secret.
+   *
+   * @param authenticator the authenticator to verify
+   * @param in the message to match against the authenticator
+   * @param key the secret key to use for verification
+   * @return true if the authenticator verifies the message according to the secret, false otherwise
+   */
+  public static boolean verify(Bytes authenticator, Bytes in, Key key) {
+    return verify(authenticator.toArrayUnsafe(), in.toArrayUnsafe(), key);
+  }
+
+  /**
+   * Verifies the authenticator of a message matches according to a secret.
+   *
+   * @param authenticator the authenticator to verify
+   * @param in the message to match against the authenticator
+   * @param key the secret key to use for verification
+   * @return true if the authenticator verifies the message according to the secret, false otherwise
+   */
+  public static boolean verify(byte[] authenticator, byte[] in, Key key) {
+    checkArgument(key.ptr != null, "Key has been destroyed");
+    if (authenticator.length != Sodium.crypto_auth_hmacsha512256_bytes()) {
+      throw new IllegalArgumentException(
+          "Expected authenticator of "
+              + Sodium.crypto_auth_hmacsha512256_bytes()
+              + " bytes, got "
+              + authenticator.length
+              + " instead");
+    }
+    int rc = Sodium.crypto_auth_hmacsha512256_verify(authenticator, in, in.length, key.ptr);
+    return rc == 0;
+  }
+}

--- a/crypto/src/main/java/net/consensys/cava/crypto/sodium/LibSodium.java
+++ b/crypto/src/main/java/net/consensys/cava/crypto/sodium/LibSodium.java
@@ -423,10 +423,10 @@ public interface LibSodium {
   long crypto_auth_hmacsha512_keybytes();
 
   // int crypto_auth_hmacsha512(unsigned char * out, const unsigned char * in, unsigned long long inlen, const unsigned char * k);
-  int crypto_auth_hmacsha512(@Out byte[] out, @In byte[] in, @In @u_int64_t long inlen, @In byte[] k);
+  int crypto_auth_hmacsha512(@Out byte[] out, @In byte[] in, @In @u_int64_t long inlen, @In Pointer k);
 
   // int crypto_auth_hmacsha512_verify(const unsigned char * h, const unsigned char * in, unsigned long long inlen, const unsigned char * k);
-  int crypto_auth_hmacsha512_verify(@In byte[] h, @In byte[] in, @In @u_int64_t long inlen, @In byte[] k);
+  int crypto_auth_hmacsha512_verify(@In byte[] h, @In byte[] in, @In @u_int64_t long inlen, @In Pointer k);
 
   // size_t crypto_auth_hmacsha512_statebytes(void);
   @ssize_t
@@ -453,10 +453,10 @@ public interface LibSodium {
   long crypto_auth_hmacsha512256_keybytes();
 
   // int crypto_auth_hmacsha512256(unsigned char * out, const unsigned char * in, unsigned long long inlen, const unsigned char * k);
-  int crypto_auth_hmacsha512256(@Out byte[] out, @In byte[] in, @In @u_int64_t long inlen, @In byte[] k);
+  int crypto_auth_hmacsha512256(@Out byte[] out, @In byte[] in, @In @u_int64_t long inlen, @In Pointer k);
 
   // int crypto_auth_hmacsha512256_verify(const unsigned char * h, const unsigned char * in, unsigned long long inlen, const unsigned char * k);
-  int crypto_auth_hmacsha512256_verify(@In byte[] h, @In byte[] in, @In @u_int64_t long inlen, @In byte[] k);
+  int crypto_auth_hmacsha512256_verify(@In byte[] h, @In byte[] in, @In @u_int64_t long inlen, @In Pointer k);
 
   // size_t crypto_auth_hmacsha512256_statebytes(void);
   @ssize_t
@@ -523,10 +523,10 @@ public interface LibSodium {
   long crypto_auth_hmacsha256_keybytes();
 
   // int crypto_auth_hmacsha256(unsigned char * out, const unsigned char * in, unsigned long long inlen, const unsigned char * k);
-  int crypto_auth_hmacsha256(@Out byte[] out, @In byte[] in, @In @u_int64_t long inlen, @In byte[] k);
+  int crypto_auth_hmacsha256(@Out byte[] out, @In byte[] in, @In @u_int64_t long inlen, @In Pointer k);
 
   // int crypto_auth_hmacsha256_verify(const unsigned char * h, const unsigned char * in, unsigned long long inlen, const unsigned char * k);
-  int crypto_auth_hmacsha256_verify(@In byte[] h, @In byte[] in, @In @u_int64_t long inlen, @In byte[] k);
+  int crypto_auth_hmacsha256_verify(@In byte[] h, @In byte[] in, @In @u_int64_t long inlen, @In Pointer k);
 
   // size_t crypto_auth_hmacsha256_statebytes(void);
   @ssize_t

--- a/crypto/src/main/java/net/consensys/cava/crypto/sodium/Sodium.java
+++ b/crypto/src/main/java/net/consensys/cava/crypto/sodium/Sodium.java
@@ -769,11 +769,11 @@ public final class Sodium {
     return libSodium().crypto_auth_hmacsha512_keybytes();
   }
 
-  static int crypto_auth_hmacsha512(byte[] out, byte[] in, long inlen, byte[] k) {
+  static int crypto_auth_hmacsha512(byte[] out, byte[] in, long inlen, Pointer k) {
     return libSodium().crypto_auth_hmacsha512(out, in, inlen, k);
   }
 
-  static int crypto_auth_hmacsha512_verify(byte[] h, byte[] in, long inlen, byte[] k) {
+  static int crypto_auth_hmacsha512_verify(byte[] h, byte[] in, long inlen, Pointer k) {
     return libSodium().crypto_auth_hmacsha512_verify(h, in, inlen, k);
   }
 
@@ -805,11 +805,11 @@ public final class Sodium {
     return libSodium().crypto_auth_hmacsha512256_keybytes();
   }
 
-  static int crypto_auth_hmacsha512256(byte[] out, byte[] in, long inlen, byte[] k) {
+  static int crypto_auth_hmacsha512256(byte[] out, byte[] in, long inlen, Pointer k) {
     return libSodium().crypto_auth_hmacsha512256(out, in, inlen, k);
   }
 
-  static int crypto_auth_hmacsha512256_verify(byte[] h, byte[] in, long inlen, byte[] k) {
+  static int crypto_auth_hmacsha512256_verify(byte[] h, byte[] in, long inlen, Pointer k) {
     return libSodium().crypto_auth_hmacsha512256_verify(h, in, inlen, k);
   }
 
@@ -889,11 +889,11 @@ public final class Sodium {
     return libSodium().crypto_auth_hmacsha256_keybytes();
   }
 
-  static int crypto_auth_hmacsha256(byte[] out, byte[] in, long inlen, byte[] k) {
+  static int crypto_auth_hmacsha256(byte[] out, byte[] in, long inlen, Pointer k) {
     return libSodium().crypto_auth_hmacsha256(out, in, inlen, k);
   }
 
-  static int crypto_auth_hmacsha256_verify(byte[] h, byte[] in, long inlen, byte[] k) {
+  static int crypto_auth_hmacsha256_verify(byte[] h, byte[] in, long inlen, Pointer k) {
     return libSodium().crypto_auth_hmacsha256_verify(h, in, inlen, k);
   }
 

--- a/crypto/src/test/java/net/consensys/cava/crypto/sodium/HMACSHA256Test.java
+++ b/crypto/src/test/java/net/consensys/cava/crypto/sodium/HMACSHA256Test.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.crypto.sodium;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import net.consensys.cava.bytes.Bytes;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class HMACSHA256Test {
+  @BeforeAll
+  static void checkAvailable() {
+    assumeTrue(Sodium.isAvailable(), "Sodium native library is not available");
+  }
+
+  @Test
+  void testHmacsha256() {
+    HMACSHA256.Key key = HMACSHA256.Key.random();
+    Bytes authenticator = HMACSHA256.authenticate(Bytes.fromHexString("deadbeef"), key);
+    assertTrue(HMACSHA256.verify(authenticator, Bytes.fromHexString("deadbeef"), key));
+  }
+
+  @Test
+  void testHmacsha256InvalidAuthenticator() {
+    HMACSHA256.Key key = HMACSHA256.Key.random();
+    Bytes authenticator = HMACSHA256.authenticate(Bytes.fromHexString("deadbeef"), key);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> HMACSHA256
+            .verify(Bytes.concatenate(authenticator, Bytes.of(1, 2, 3)), Bytes.fromHexString("deadbeef"), key));
+  }
+
+  @Test
+  void testHmacsha512NoMatch() {
+    HMACSHA256.Key key = HMACSHA256.Key.random();
+    Bytes authenticator = HMACSHA256.authenticate(Bytes.fromHexString("deadbeef"), key);
+    assertFalse(HMACSHA256.verify(authenticator.reverse(), Bytes.fromHexString("deadbeef"), key));
+  }
+}

--- a/crypto/src/test/java/net/consensys/cava/crypto/sodium/HMACSHA512256Test.java
+++ b/crypto/src/test/java/net/consensys/cava/crypto/sodium/HMACSHA512256Test.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.crypto.sodium;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import net.consensys.cava.bytes.Bytes;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class HMACSHA512256Test {
+  @BeforeAll
+  static void checkAvailable() {
+    assumeTrue(Sodium.isAvailable(), "Sodium native library is not available");
+  }
+
+  @Test
+  void testHmacsha512256() {
+    HMACSHA512256.Key key = HMACSHA512256.Key.random();
+    Bytes authenticator = HMACSHA512256.authenticate(Bytes.fromHexString("deadbeef"), key);
+    assertTrue(HMACSHA512256.verify(authenticator, Bytes.fromHexString("deadbeef"), key));
+  }
+
+  @Test
+  void testHmacsha512256InvalidAuthenticator() {
+    HMACSHA512256.Key key = HMACSHA512256.Key.random();
+    Bytes authenticator = HMACSHA512256.authenticate(Bytes.fromHexString("deadbeef"), key);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> HMACSHA512256
+            .verify(Bytes.concatenate(authenticator, Bytes.of(1, 2, 3)), Bytes.fromHexString("deadbeef"), key));
+  }
+
+  @Test
+  void testHmacsha512256NoMatch() {
+    HMACSHA512256.Key key = HMACSHA512256.Key.random();
+    Bytes authenticator = HMACSHA512256.authenticate(Bytes.fromHexString("deadbeef"), key);
+    assertFalse(HMACSHA512256.verify(authenticator.reverse(), Bytes.fromHexString("deadbeef"), key));
+  }
+}

--- a/crypto/src/test/java/net/consensys/cava/crypto/sodium/HMACSHA512Test.java
+++ b/crypto/src/test/java/net/consensys/cava/crypto/sodium/HMACSHA512Test.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.crypto.sodium;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import net.consensys.cava.bytes.Bytes;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class HMACSHA512Test {
+  @BeforeAll
+  static void checkAvailable() {
+    assumeTrue(Sodium.isAvailable(), "Sodium native library is not available");
+  }
+
+  @Test
+  void testHmacsha512() {
+    HMACSHA512.Key key = HMACSHA512.Key.random();
+    Bytes authenticator = HMACSHA512.authenticate(Bytes.fromHexString("deadbeef"), key);
+    assertTrue(HMACSHA512.verify(authenticator, Bytes.fromHexString("deadbeef"), key));
+  }
+
+  @Test
+  void testHmacsha512InvalidAuthenticator() {
+    HMACSHA512.Key key = HMACSHA512.Key.random();
+    Bytes authenticator = HMACSHA512.authenticate(Bytes.fromHexString("deadbeef"), key);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> HMACSHA512
+            .verify(Bytes.concatenate(authenticator, Bytes.of(1, 2, 3)), Bytes.fromHexString("deadbeef"), key));
+  }
+
+  @Test
+  void testHmacsha512NoMatch() {
+    HMACSHA512.Key key = HMACSHA512.Key.random();
+    Bytes authenticator = HMACSHA512.authenticate(Bytes.fromHexString("deadbeef"), key);
+    assertFalse(HMACSHA512.verify(authenticator.reverse(), Bytes.fromHexString("deadbeef"), key));
+  }
+}


### PR DESCRIPTION
Supports mac computation with HMAC-SHA-256, HMAC-SHA-512, HMAC-SHA-512-256.

Extracted from #162 