### PR TITLE
Internally represent UInt64 with a long

### DIFF
--- a/bytes/src/main/java/net/consensys/cava/bytes/MutableBytes.java
+++ b/bytes/src/main/java/net/consensys/cava/bytes/MutableBytes.java
@@ -289,7 +289,9 @@ public interface MutableBytes extends Bytes {
   /**
    * Increments the value of the bytes by 1, treating the value as big endian.
    *
-   * If incrementing overflows the value, all bits flip, ie incrementing 0xFFFF will return 0x0000.
+   * If incrementing overflows the value then all bits flip, i.e. incrementing 0xFFFF will return 0x0000.
+   *
+   * @return this value
    */
   default MutableBytes increment() {
     for (int i = size() - 1; i >= 0; --i) {
@@ -307,7 +309,9 @@ public interface MutableBytes extends Bytes {
   /**
    * Decrements the value of the bytes by 1, treating the value as big endian.
    *
-   * If decrementing underflows the value, all bits flip, ie decrementing 0x0000 will return 0xFFFF.
+   * If decrementing underflows the value then all bits flip, i.e. decrementing 0x0000 will return 0xFFFF.
+   *
+   * @return this value
    */
   default MutableBytes decrement() {
     for (int i = size() - 1; i >= 0; --i) {

--- a/units/src/main/java/net/consensys/cava/units/bigints/UInt256Value.java
+++ b/units/src/main/java/net/consensys/cava/units/bigints/UInt256Value.java
@@ -59,14 +59,14 @@ public interface UInt256Value<T extends UInt256Value<T>> extends Comparable<T> {
   /**
    * Returns a value that is {@code (this + value)}.
    *
-   * @param value The amount to be added to this value.
+   * @param value the amount to be added to this value
    * @return {@code this + value}
    * @throws ArithmeticException if the result of the addition overflows
    */
-  default T tryAdd(T value) {
+  default T addExact(T value) {
     T result = add(value);
-    if (this.compareTo(result) > 0) {
-      throw new ArithmeticException("Value overflowed");
+    if (compareTo(result) > 0) {
+      throw new ArithmeticException("UInt256 overflow");
     }
     return result;
   }
@@ -82,14 +82,14 @@ public interface UInt256Value<T extends UInt256Value<T>> extends Comparable<T> {
   /**
    * Returns a value that is {@code (this + value)}.
    *
-   * @param value The amount to be added to this value.
+   * @param value the amount to be added to this value
    * @return {@code this + value}
    * @throws ArithmeticException if the result of the addition overflows
    */
-  default T tryAdd(long value) {
+  default T addExact(long value) {
     T result = add(value);
-    if (this.compareTo(result) > 0) {
-      throw new ArithmeticException("Value overflowed");
+    if ((value > 0 && compareTo(result) > 0) || (value < 0 && compareTo(result) < 0)) {
+      throw new ArithmeticException("UInt256 overflow");
     }
     return result;
   }
@@ -135,14 +135,14 @@ public interface UInt256Value<T extends UInt256Value<T>> extends Comparable<T> {
   /**
    * Returns a value that is {@code (this - value)}.
    *
-   * @param value The amount to be subtracted to this value.
+   * @param value the amount to be subtracted to this value
    * @return {@code this - value}
-   * @throws ArithmeticException if the result of the addition underflows
+   * @throws ArithmeticException if the result of the addition overflows
    */
-  default T trySubtract(T value) {
+  default T subtractExact(T value) {
     T result = subtract(value);
-    if (this.compareTo(result) < 0) {
-      throw new ArithmeticException("Value underflowed");
+    if (compareTo(result) < 0) {
+      throw new ArithmeticException("UInt256 overflow");
     }
     return result;
   }
@@ -158,14 +158,14 @@ public interface UInt256Value<T extends UInt256Value<T>> extends Comparable<T> {
   /**
    * Returns a value that is {@code (this - value)}.
    *
-   * @param value The amount to be subtracted to this value.
+   * @param value the amount to be subtracted to this value
    * @return {@code this - value}
-   * @throws ArithmeticException if the result of the addition underflows
+   * @throws ArithmeticException if the result of the addition overflows
    */
-  default T trySubtract(long value) {
+  default T subtractExact(long value) {
     T result = subtract(value);
-    if (this.compareTo(result) < 0) {
-      throw new ArithmeticException("Value underflowed");
+    if ((value > 0 && compareTo(result) < 0) || (value < 0 && compareTo(result) > 0)) {
+      throw new ArithmeticException("UInt256 overflow");
     }
     return result;
   }
@@ -294,8 +294,7 @@ public interface UInt256Value<T extends UInt256Value<T>> extends Comparable<T> {
 
   /**
    * @return This value as a java {@code int} assuming it is small enough to fit an {@code int}.
-   * @throws ArithmeticException If the value does not fit an {@code int}, that is if {@code
-   *     !fitsInt()}.
+   * @throws ArithmeticException If the value does not fit an {@code int}, that is if {@code !fitsInt()}.
    */
   default int intValue() {
     if (!fitsInt()) {
@@ -319,8 +318,7 @@ public interface UInt256Value<T extends UInt256Value<T>> extends Comparable<T> {
 
   /**
    * @return This value as a java {@code long} assuming it is small enough to fit a {@code long}.
-   * @throws ArithmeticException If the value does not fit a {@code long}, that is if {@code
-   *     !fitsLong()}.
+   * @throws ArithmeticException If the value does not fit a {@code long}, that is if {@code !fitsLong()}.
    */
   default long toLong() {
     if (!fitsLong()) {

--- a/units/src/main/java/net/consensys/cava/units/bigints/UInt384.java
+++ b/units/src/main/java/net/consensys/cava/units/bigints/UInt384.java
@@ -30,7 +30,7 @@ import java.util.Arrays;
 public final class UInt384 implements UInt384Value<UInt384> {
   private final static int MAX_CONSTANT = 64;
   private final static BigInteger BI_MAX_CONSTANT = BigInteger.valueOf(MAX_CONSTANT);
-  private static UInt384 CONSTANTS[] = new UInt384[MAX_CONSTANT + 1];
+  private static UInt384[] CONSTANTS = new UInt384[MAX_CONSTANT + 1];
   static {
     CONSTANTS[0] = new UInt384(Bytes48.ZERO);
     for (int i = 1; i <= MAX_CONSTANT; ++i) {
@@ -46,8 +46,6 @@ public final class UInt384 implements UInt384Value<UInt384> {
   public final static UInt384 ZERO = valueOf(0);
   /** The value 1 */
   public final static UInt384 ONE = valueOf(1);
-  /** The value 10 */
-  public final static UInt384 TEN = valueOf(10);
 
   private static final int INTS_SIZE = 48 / 4;
   // The mask is used to obtain the value of an int as if it were unsigned.
@@ -55,7 +53,7 @@ public final class UInt384 implements UInt384Value<UInt384> {
   private static final BigInteger P_2_384 = BigInteger.valueOf(2).pow(384);
 
   // The unsigned int components of the value
-  private final int ints[];
+  private final int[] ints;
 
   /**
    * Return a {@code UInt384} containing the specified value.
@@ -72,21 +70,16 @@ public final class UInt384 implements UInt384Value<UInt384> {
     return new UInt384(value);
   }
 
-  private UInt384(long value) {
-    this.ints = new int[INTS_SIZE];
-    this.ints[INTS_SIZE - 2] = (int) ((value >>> 32) & LONG_MASK);
-    this.ints[INTS_SIZE - 1] = (int) (value & LONG_MASK);
-  }
-
   /**
    * Return a {@link UInt384} containing the specified value.
    *
-   * @param value The value to create a {@link UInt384} for.
-   * @return A {@link UInt384} containing the specified value.
-   * @throws IllegalArgumentException If the value is negative.
+   * @param value the value to create a {@link UInt384} for
+   * @return a {@link UInt384} containing the specified value
+   * @throws IllegalArgumentException if the value is negative or too large to be represented as a UInt384
    */
   public static UInt384 valueOf(BigInteger value) {
     checkArgument(value.signum() >= 0, "Argument must be positive");
+    checkArgument(value.bitLength() <= 384, "Argument is too large to represent a UInt384");
     if (value.compareTo(BI_MAX_CONSTANT) <= 0) {
       return CONSTANTS[value.intValue()];
     }
@@ -129,7 +122,13 @@ public final class UInt384 implements UInt384Value<UInt384> {
     }
   }
 
-  private UInt384(int ints[]) {
+  private UInt384(long value) {
+    this.ints = new int[INTS_SIZE];
+    this.ints[INTS_SIZE - 2] = (int) ((value >>> 32) & LONG_MASK);
+    this.ints[INTS_SIZE - 1] = (int) (value & LONG_MASK);
+  }
+
+  private UInt384(int[] ints) {
     this.ints = ints;
   }
 
@@ -155,7 +154,7 @@ public final class UInt384 implements UInt384Value<UInt384> {
     if (isZero()) {
       return value;
     }
-    int result[] = new int[INTS_SIZE];
+    int[] result = new int[INTS_SIZE];
     boolean constant = true;
     long sum = (this.ints[INTS_SIZE - 1] & LONG_MASK) + (value.ints[INTS_SIZE - 1] & LONG_MASK);
     result[INTS_SIZE - 1] = (int) (sum & LONG_MASK);
@@ -181,7 +180,7 @@ public final class UInt384 implements UInt384Value<UInt384> {
     if (value > 0 && isZero()) {
       return UInt384.valueOf(value);
     }
-    int result[] = new int[INTS_SIZE];
+    int[] result = new int[INTS_SIZE];
     boolean constant = true;
     long sum = (this.ints[INTS_SIZE - 1] & LONG_MASK) + (value & LONG_MASK);
     result[INTS_SIZE - 1] = (int) (sum & LONG_MASK);
@@ -236,7 +235,7 @@ public final class UInt384 implements UInt384Value<UInt384> {
       return this;
     }
 
-    int result[] = new int[INTS_SIZE];
+    int[] result = new int[INTS_SIZE];
     boolean constant = true;
     long sum = (this.ints[INTS_SIZE - 1] & LONG_MASK) + ((~value.ints[INTS_SIZE - 1]) & LONG_MASK) + 1;
     result[INTS_SIZE - 1] = (int) (sum & LONG_MASK);
@@ -271,7 +270,7 @@ public final class UInt384 implements UInt384Value<UInt384> {
   }
 
   private static UInt384 multiply(int[] x, int[] y) {
-    int result[] = new int[INTS_SIZE + INTS_SIZE];
+    int[] result = new int[INTS_SIZE + INTS_SIZE];
 
     long carry = 0;
     for (int j = INTS_SIZE - 1, k = INTS_SIZE + INTS_SIZE - 1; j >= 0; j--, k--) {
@@ -448,7 +447,7 @@ public final class UInt384 implements UInt384Value<UInt384> {
    * @return The result of a bit-wise AND.
    */
   public UInt384 and(UInt384 value) {
-    int result[] = new int[INTS_SIZE];
+    int[] result = new int[INTS_SIZE];
     for (int i = INTS_SIZE - 1; i >= 0; --i) {
       result[i] = this.ints[i] & value.ints[i];
     }
@@ -464,7 +463,7 @@ public final class UInt384 implements UInt384Value<UInt384> {
    * @return The result of a bit-wise AND.
    */
   public UInt384 and(Bytes48 bytes) {
-    int result[] = new int[INTS_SIZE];
+    int[] result = new int[INTS_SIZE];
     for (int i = INTS_SIZE - 1, j = 28; i >= 0; --i, j -= 4) {
       int other = ((int) bytes.get(j) & 0xFF) << 24;
       other |= ((int) bytes.get(j + 1) & 0xFF) << 16;
@@ -484,7 +483,7 @@ public final class UInt384 implements UInt384Value<UInt384> {
    * @return The result of a bit-wise OR.
    */
   public UInt384 or(UInt384 value) {
-    int result[] = new int[INTS_SIZE];
+    int[] result = new int[INTS_SIZE];
     for (int i = INTS_SIZE - 1; i >= 0; --i) {
       result[i] = this.ints[i] | value.ints[i];
     }
@@ -500,7 +499,7 @@ public final class UInt384 implements UInt384Value<UInt384> {
    * @return The result of a bit-wise OR.
    */
   public UInt384 or(Bytes48 bytes) {
-    int result[] = new int[INTS_SIZE];
+    int[] result = new int[INTS_SIZE];
     for (int i = INTS_SIZE - 1, j = 28; i >= 0; --i, j -= 4) {
       result[i] = this.ints[i] | (((int) bytes.get(j) & 0xFF) << 24);
       result[i] |= ((int) bytes.get(j + 1) & 0xFF) << 16;
@@ -519,7 +518,7 @@ public final class UInt384 implements UInt384Value<UInt384> {
    * @return The result of a bit-wise XOR.
    */
   public UInt384 xor(UInt384 value) {
-    int result[] = new int[INTS_SIZE];
+    int[] result = new int[INTS_SIZE];
     for (int i = INTS_SIZE - 1; i >= 0; --i) {
       result[i] = this.ints[i] ^ value.ints[i];
     }
@@ -535,7 +534,7 @@ public final class UInt384 implements UInt384Value<UInt384> {
    * @return The result of a bit-wise XOR.
    */
   public UInt384 xor(Bytes48 bytes) {
-    int result[] = new int[INTS_SIZE];
+    int[] result = new int[INTS_SIZE];
     for (int i = INTS_SIZE - 1, j = 28; i >= 0; --i, j -= 4) {
       result[i] = this.ints[i] ^ (((int) bytes.get(j) & 0xFF) << 24);
       result[i] ^= ((int) bytes.get(j + 1) & 0xFF) << 16;
@@ -551,7 +550,7 @@ public final class UInt384 implements UInt384Value<UInt384> {
    * @return The result of a bit-wise NOT.
    */
   public UInt384 not() {
-    int result[] = new int[INTS_SIZE];
+    int[] result = new int[INTS_SIZE];
     for (int i = INTS_SIZE - 1; i >= 0; --i) {
       result[i] = ~(this.ints[i]);
     }
@@ -571,7 +570,7 @@ public final class UInt384 implements UInt384Value<UInt384> {
     if (distance >= 384) {
       return ZERO;
     }
-    int result[] = new int[INTS_SIZE];
+    int[] result = new int[INTS_SIZE];
     int d = distance / 32;
     int s = distance % 32;
 
@@ -603,7 +602,7 @@ public final class UInt384 implements UInt384Value<UInt384> {
     if (distance >= 384) {
       return ZERO;
     }
-    int result[] = new int[INTS_SIZE];
+    int[] result = new int[INTS_SIZE];
     int d = distance / 32;
     int s = distance % 32;
 
@@ -704,7 +703,7 @@ public final class UInt384 implements UInt384Value<UInt384> {
 
   @Override
   public BigInteger toBigInteger() {
-    byte mag[] = new byte[48];
+    byte[] mag = new byte[48];
     for (int i = 0, j = 0; i < INTS_SIZE; ++i) {
       mag[j++] = (byte) (this.ints[i] >>> 24);
       mag[j++] = (byte) ((this.ints[i] >>> 16) & 0xFF);

--- a/units/src/main/java/net/consensys/cava/units/bigints/UInt384Value.java
+++ b/units/src/main/java/net/consensys/cava/units/bigints/UInt384Value.java
@@ -59,14 +59,14 @@ public interface UInt384Value<T extends UInt384Value<T>> extends Comparable<T> {
   /**
    * Returns a value that is {@code (this + value)}.
    *
-   * @param value The amount to be added to this value.
+   * @param value the amount to be added to this value
    * @return {@code this + value}
    * @throws ArithmeticException if the result of the addition overflows
    */
-  default T tryAdd(T value) {
+  default T addExact(T value) {
     T result = add(value);
-    if (this.compareTo(result) > 0) {
-      throw new ArithmeticException("Value overflowed");
+    if (compareTo(result) > 0) {
+      throw new ArithmeticException("UInt384 overflow");
     }
     return result;
   }
@@ -82,14 +82,14 @@ public interface UInt384Value<T extends UInt384Value<T>> extends Comparable<T> {
   /**
    * Returns a value that is {@code (this + value)}.
    *
-   * @param value The amount to be added to this value.
+   * @param value the amount to be added to this value
    * @return {@code this + value}
    * @throws ArithmeticException if the result of the addition overflows
    */
-  default T tryAdd(long value) {
+  default T addExact(long value) {
     T result = add(value);
-    if (this.compareTo(result) > 0) {
-      throw new ArithmeticException("Value overflowed");
+    if ((value > 0 && compareTo(result) > 0) || (value < 0 && compareTo(result) < 0)) {
+      throw new ArithmeticException("UInt384 overflow");
     }
     return result;
   }
@@ -135,14 +135,14 @@ public interface UInt384Value<T extends UInt384Value<T>> extends Comparable<T> {
   /**
    * Returns a value that is {@code (this - value)}.
    *
-   * @param value The amount to be subtracted to this value.
+   * @param value the amount to be subtracted to this value
    * @return {@code this - value}
-   * @throws ArithmeticException if the result of the addition underflows
+   * @throws ArithmeticException if the result of the addition overflows
    */
-  default T trySubtract(T value) {
+  default T subtractExact(T value) {
     T result = subtract(value);
-    if (this.compareTo(result) < 0) {
-      throw new ArithmeticException("Value underflowed");
+    if (compareTo(result) < 0) {
+      throw new ArithmeticException("UInt384 overflow");
     }
     return result;
   }
@@ -158,14 +158,14 @@ public interface UInt384Value<T extends UInt384Value<T>> extends Comparable<T> {
   /**
    * Returns a value that is {@code (this - value)}.
    *
-   * @param value The amount to be subtracted to this value.
+   * @param value the amount to be subtracted to this value
    * @return {@code this - value}
-   * @throws ArithmeticException if the result of the addition underflows
+   * @throws ArithmeticException if the result of the addition overflows
    */
-  default T trySubtract(long value) {
+  default T subtractExact(long value) {
     T result = subtract(value);
-    if (this.compareTo(result) < 0) {
-      throw new ArithmeticException("Value underflowed");
+    if ((value > 0 && compareTo(result) < 0) || (value < 0 && compareTo(result) > 0)) {
+      throw new ArithmeticException("UInt384 overflow");
     }
     return result;
   }
@@ -294,8 +294,7 @@ public interface UInt384Value<T extends UInt384Value<T>> extends Comparable<T> {
 
   /**
    * @return This value as a java {@code int} assuming it is small enough to fit an {@code int}.
-   * @throws ArithmeticException If the value does not fit an {@code int}, that is if {@code
-   *     !fitsInt()}.
+   * @throws ArithmeticException If the value does not fit an {@code int}, that is if {@code !fitsInt()}.
    */
   default int intValue() {
     if (!fitsInt()) {
@@ -319,8 +318,7 @@ public interface UInt384Value<T extends UInt384Value<T>> extends Comparable<T> {
 
   /**
    * @return This value as a java {@code long} assuming it is small enough to fit a {@code long}.
-   * @throws ArithmeticException If the value does not fit a {@code long}, that is if {@code
-   *     !fitsLong()}.
+   * @throws ArithmeticException If the value does not fit a {@code long}, that is if {@code !fitsLong()}.
    */
   default long toLong() {
     if (!fitsLong()) {

--- a/units/src/main/java/net/consensys/cava/units/bigints/UInt64.java
+++ b/units/src/main/java/net/consensys/cava/units/bigints/UInt64.java
@@ -18,7 +18,6 @@ import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.MutableBytes;
 
 import java.math.BigInteger;
-import java.util.Arrays;
 
 /**
  * An unsigned 64-bit precision number.
@@ -27,10 +26,9 @@ import java.util.Arrays;
  */
 public final class UInt64 implements UInt64Value<UInt64> {
   private final static int MAX_CONSTANT = 64;
-  private final static BigInteger BI_MAX_CONSTANT = BigInteger.valueOf(MAX_CONSTANT);
-  private static UInt64 CONSTANTS[] = new UInt64[MAX_CONSTANT + 1];
+  private static UInt64[] CONSTANTS = new UInt64[MAX_CONSTANT + 1];
   static {
-    CONSTANTS[0] = new UInt64(Bytes.wrap(new byte[8]));
+    CONSTANTS[0] = new UInt64(0);
     for (int i = 1; i <= MAX_CONSTANT; ++i) {
       CONSTANTS[i] = new UInt64(i);
     }
@@ -39,21 +37,15 @@ public final class UInt64 implements UInt64Value<UInt64> {
   /** The minimum value of a UInt64 */
   public final static UInt64 MIN_VALUE = valueOf(0);
   /** The maximum value of a UInt64 */
-  public final static UInt64 MAX_VALUE = new UInt64(Bytes.wrap(new byte[8]).not());
+  public final static UInt64 MAX_VALUE = new UInt64(~0L);
   /** The value 0 */
   public final static UInt64 ZERO = valueOf(0);
   /** The value 1 */
   public final static UInt64 ONE = valueOf(1);
-  /** The value 10 */
-  public final static UInt64 TEN = valueOf(10);
 
-  private static final int INTS_SIZE = 8 / 4;
-  // The mask is used to obtain the value of an int as if it were unsigned.
-  private static final long LONG_MASK = 0xFFFFFFFFL;
   private static final BigInteger P_2_64 = BigInteger.valueOf(2).pow(64);
 
-  // The unsigned int components of the value
-  private final int ints[];
+  private final long value;
 
   /**
    * Return a {@code UInt64} containing the specified value.
@@ -64,36 +56,20 @@ public final class UInt64 implements UInt64Value<UInt64> {
    */
   public static UInt64 valueOf(long value) {
     checkArgument(value >= 0, "Argument must be positive");
-    if (value <= MAX_CONSTANT) {
-      return CONSTANTS[(int) value];
-    }
-    return new UInt64(value);
-  }
-
-  private UInt64(long value) {
-    this.ints = new int[INTS_SIZE];
-    this.ints[INTS_SIZE - 2] = (int) ((value >>> 32) & LONG_MASK);
-    this.ints[INTS_SIZE - 1] = (int) (value & LONG_MASK);
+    return create(value);
   }
 
   /**
    * Return a {@link UInt64} containing the specified value.
    *
-   * @param value The value to create a {@link UInt64} for.
-   * @return A {@link UInt64} containing the specified value.
-   * @throws IllegalArgumentException If the value is negative.
+   * @param value the value to create a {@link UInt64} for
+   * @return a {@link UInt64} containing the specified value
+   * @throws IllegalArgumentException if the value is negative or too large to be represented as a UInt64
    */
   public static UInt64 valueOf(BigInteger value) {
     checkArgument(value.signum() >= 0, "Argument must be positive");
-    if (value.compareTo(BI_MAX_CONSTANT) <= 0) {
-      return CONSTANTS[value.intValue()];
-    }
-    int[] ints = new int[INTS_SIZE];
-    for (int i = INTS_SIZE - 1; i >= 0; --i) {
-      ints[i] = value.intValue();
-      value = value.shiftRight(32);
-    }
-    return new UInt64(ints);
+    checkArgument(value.bitLength() <= 64, "Argument is too large to represent a UInt64");
+    return create(value.longValue());
   }
 
   /**
@@ -104,7 +80,8 @@ public final class UInt64 implements UInt64Value<UInt64> {
    * @throws IllegalArgumentException if {@code bytes.size() &gt; 8}.
    */
   public static UInt64 fromBytes(Bytes bytes) {
-    return new UInt64(Bytes.concatenate(Bytes.wrap(new byte[8 - bytes.size()]), bytes));
+    checkArgument(bytes.size() <= 8, "Argument is greater than 8 bytes");
+    return create(bytes.toLong());
   }
 
   /**
@@ -120,55 +97,31 @@ public final class UInt64 implements UInt64Value<UInt64> {
     return fromBytes(Bytes.fromHexStringLenient(str));
   }
 
-  private UInt64(Bytes bytes) {
-    this.ints = new int[INTS_SIZE];
-    for (int i = 0, j = 0; i < INTS_SIZE; ++i, j += 4) {
-      ints[i] = bytes.getInt(j);
+  private static UInt64 create(long value) {
+    if (value >= 0 && value <= MAX_CONSTANT) {
+      return CONSTANTS[(int) value];
     }
+    return new UInt64(value);
   }
 
-  private UInt64(int ints[]) {
-    this.ints = ints;
+  private UInt64(long value) {
+    this.value = value;
   }
 
-  @SuppressWarnings("ReferenceEquality")
   @Override
   public boolean isZero() {
-    if (this == ZERO) {
-      return true;
-    }
-    for (int i = INTS_SIZE - 1; i >= 0; --i) {
-      if (this.ints[i] != 0) {
-        return false;
-      }
-    }
-    return true;
+    return this.value == 0;
   }
 
   @Override
   public UInt64 add(UInt64 value) {
-    if (value.isZero()) {
+    if (value.value == 0) {
       return this;
     }
-    if (isZero()) {
+    if (this.value == 0) {
       return value;
     }
-    int result[] = new int[INTS_SIZE];
-    boolean constant = true;
-    long sum = (this.ints[INTS_SIZE - 1] & LONG_MASK) + (value.ints[INTS_SIZE - 1] & LONG_MASK);
-    result[INTS_SIZE - 1] = (int) (sum & LONG_MASK);
-    if (result[INTS_SIZE - 1] < 0 || result[INTS_SIZE - 1] > MAX_CONSTANT) {
-      constant = false;
-    }
-    for (int i = INTS_SIZE - 2; i >= 0; --i) {
-      sum = (this.ints[i] & LONG_MASK) + (value.ints[i] & LONG_MASK) + (sum >>> 32);
-      result[i] = (int) (sum & LONG_MASK);
-      constant &= result[i] == 0;
-    }
-    if (constant) {
-      return CONSTANTS[result[INTS_SIZE - 1]];
-    }
-    return new UInt64(result);
+    return create(this.value + value.value);
   }
 
   @Override
@@ -176,29 +129,7 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (value == 0) {
       return this;
     }
-    if (value > 0 && isZero()) {
-      return UInt64.valueOf(value);
-    }
-    int result[] = new int[INTS_SIZE];
-    boolean constant = true;
-    long sum = (this.ints[INTS_SIZE - 1] & LONG_MASK) + (value & LONG_MASK);
-    result[INTS_SIZE - 1] = (int) (sum & LONG_MASK);
-    if (result[INTS_SIZE - 1] < 0 || result[INTS_SIZE - 1] > MAX_CONSTANT) {
-      constant = false;
-    }
-    sum = (this.ints[INTS_SIZE - 2] & LONG_MASK) + (value >>> 32) + (sum >>> 32);
-    result[INTS_SIZE - 2] = (int) (sum & LONG_MASK);
-    constant &= result[INTS_SIZE - 2] == 0;
-    long signExtent = (value >> 63) & LONG_MASK;
-    for (int i = INTS_SIZE - 3; i >= 0; --i) {
-      sum = (this.ints[i] & LONG_MASK) + signExtent + (sum >>> 32);
-      result[i] = (int) (sum & LONG_MASK);
-      constant &= result[i] == 0;
-    }
-    if (constant) {
-      return CONSTANTS[result[INTS_SIZE - 1]];
-    }
-    return new UInt64(result);
+    return create(this.value + value);
   }
 
   @Override
@@ -206,7 +137,7 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (modulus.isZero()) {
       throw new ArithmeticException("addMod with zero modulus");
     }
-    return UInt64.valueOf(toBigInteger().add(value.toBigInteger()).mod(modulus.toBigInteger()));
+    return create(toBigInteger().add(value.toBigInteger()).mod(modulus.toBigInteger()).longValue());
   }
 
   @Override
@@ -214,7 +145,7 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (modulus.isZero()) {
       throw new ArithmeticException("addMod with zero modulus");
     }
-    return UInt64.valueOf(toBigInteger().add(BigInteger.valueOf(value)).mod(modulus.toBigInteger()));
+    return create(toBigInteger().add(BigInteger.valueOf(value)).mod(modulus.toBigInteger()).longValue());
   }
 
   @Override
@@ -225,7 +156,7 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (modulus < 0) {
       throw new ArithmeticException("addMod unsigned with negative modulus");
     }
-    return UInt64.valueOf(toBigInteger().add(BigInteger.valueOf(value)).mod(BigInteger.valueOf(modulus)));
+    return create(toBigInteger().add(BigInteger.valueOf(value)).mod(BigInteger.valueOf(modulus)).longValue());
   }
 
   @Override
@@ -233,23 +164,7 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (value.isZero()) {
       return this;
     }
-
-    int result[] = new int[INTS_SIZE];
-    boolean constant = true;
-    long sum = (this.ints[INTS_SIZE - 1] & LONG_MASK) + ((~value.ints[INTS_SIZE - 1]) & LONG_MASK) + 1;
-    result[INTS_SIZE - 1] = (int) (sum & LONG_MASK);
-    if (result[INTS_SIZE - 1] < 0 || result[INTS_SIZE - 1] > MAX_CONSTANT) {
-      constant = false;
-    }
-    for (int i = INTS_SIZE - 2; i >= 0; --i) {
-      sum = (this.ints[i] & LONG_MASK) + ((~value.ints[i]) & LONG_MASK) + (sum >>> 32);
-      result[i] = (int) (sum & LONG_MASK);
-      constant &= result[i] == 0;
-    }
-    if (constant) {
-      return CONSTANTS[result[INTS_SIZE - 1]];
-    }
-    return new UInt64(result);
+    return create(this.value - value.value);
   }
 
   @Override
@@ -259,60 +174,27 @@ public final class UInt64 implements UInt64Value<UInt64> {
 
   @Override
   public UInt64 multiply(UInt64 value) {
-    if (isZero() || value.isZero()) {
+    if (this.value == 0 || value.value == 0) {
       return ZERO;
     }
-    if (value.equals(UInt64.ONE)) {
+    if (value.value == 1) {
       return this;
     }
-    return multiply(this.ints, value.ints);
-  }
-
-  private static UInt64 multiply(int[] x, int[] y) {
-    int result[] = new int[INTS_SIZE + INTS_SIZE];
-
-    long carry = 0;
-    for (int j = INTS_SIZE - 1, k = INTS_SIZE + INTS_SIZE - 1; j >= 0; j--, k--) {
-      long product = (y[j] & LONG_MASK) * (x[INTS_SIZE - 1] & LONG_MASK) + carry;
-      result[k] = (int) product;
-      carry = product >>> 32;
-    }
-    result[INTS_SIZE - 1] = (int) carry;
-
-    for (int i = INTS_SIZE - 2; i >= 0; i--) {
-      carry = 0;
-      for (int j = INTS_SIZE - 1, k = INTS_SIZE + i; j >= 0; j--, k--) {
-        long product = (y[j] & LONG_MASK) * (x[i] & LONG_MASK) + (result[k] & LONG_MASK) + carry;
-
-        result[k] = (int) product;
-        carry = product >>> 32;
-      }
-      result[i] = (int) carry;
-    }
-
-    boolean constant = true;
-    for (int i = INTS_SIZE; i < (INTS_SIZE + INTS_SIZE) - 2; ++i) {
-      constant &= (result[i] == 0);
-    }
-    if (constant && result[INTS_SIZE + INTS_SIZE - 1] >= 0 && result[INTS_SIZE + INTS_SIZE - 1] <= MAX_CONSTANT) {
-      return CONSTANTS[result[INTS_SIZE + INTS_SIZE - 1]];
-    }
-    return new UInt64(Arrays.copyOfRange(result, INTS_SIZE, INTS_SIZE + INTS_SIZE));
+    return create(this.value * value.value);
   }
 
   @Override
   public UInt64 multiply(long value) {
-    if (value == 0 || isZero()) {
+    if (value < 0) {
+      throw new ArithmeticException("multiply unsigned by negative");
+    }
+    if (value == 0 || this.value == 0) {
       return ZERO;
     }
     if (value == 1) {
       return this;
     }
-    if (value < 0) {
-      throw new ArithmeticException("multiply unsigned by negative");
-    }
-    UInt64 other = new UInt64(value);
-    return multiply(this.ints, other.ints);
+    return create(this.value * value);
   }
 
   @Override
@@ -320,13 +202,13 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (modulus.isZero()) {
       throw new ArithmeticException("multiplyMod with zero modulus");
     }
-    if (isZero() || value.isZero()) {
+    if (this.value == 0 || value.value == 0) {
       return ZERO;
     }
-    if (value.equals(UInt64.ONE)) {
+    if (value.value == 1) {
       return mod(modulus);
     }
-    return UInt64.valueOf(toBigInteger().multiply(value.toBigInteger()).mod(modulus.toBigInteger()));
+    return create(toBigInteger().multiply(value.toBigInteger()).mod(modulus.toBigInteger()).longValue());
   }
 
   @Override
@@ -334,7 +216,7 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (modulus.isZero()) {
       throw new ArithmeticException("multiplyMod with zero modulus");
     }
-    if (value == 0 || isZero()) {
+    if (value == 0 || this.value == 0) {
       return ZERO;
     }
     if (value == 1) {
@@ -343,7 +225,7 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (value < 0) {
       throw new ArithmeticException("multiplyMod unsigned by negative");
     }
-    return UInt64.valueOf(toBigInteger().multiply(BigInteger.valueOf(value)).mod(modulus.toBigInteger()));
+    return create(toBigInteger().multiply(BigInteger.valueOf(value)).mod(modulus.toBigInteger()).longValue());
   }
 
   @Override
@@ -354,7 +236,7 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (modulus < 0) {
       throw new ArithmeticException("multiplyMod unsigned with negative modulus");
     }
-    if (value == 0 || isZero()) {
+    if (value == 0 || this.value == 0) {
       return ZERO;
     }
     if (value == 1) {
@@ -363,18 +245,18 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (value < 0) {
       throw new ArithmeticException("multiplyMod unsigned by negative");
     }
-    return UInt64.valueOf(toBigInteger().multiply(BigInteger.valueOf(value)).mod(BigInteger.valueOf(modulus)));
+    return create(toBigInteger().multiply(BigInteger.valueOf(value)).mod(BigInteger.valueOf(modulus)).longValue());
   }
 
   @Override
   public UInt64 divide(UInt64 value) {
-    if (value.isZero()) {
+    if (value.value == 0) {
       throw new ArithmeticException("divide by zero");
     }
-    if (value.equals(UInt64.ONE)) {
+    if (value.value == 1) {
       return this;
     }
-    return UInt64.valueOf(toBigInteger().divide(value.toBigInteger()));
+    return create(toBigInteger().divide(value.toBigInteger()).longValue());
   }
 
   @Override
@@ -391,17 +273,17 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (isPowerOf2(value)) {
       return shiftRight(log2(value));
     }
-    return UInt64.valueOf(toBigInteger().divide(BigInteger.valueOf(value)));
+    return create(toBigInteger().divide(BigInteger.valueOf(value)).longValue());
   }
 
   @Override
   public UInt64 pow(UInt64 exponent) {
-    return UInt64.valueOf(toBigInteger().modPow(exponent.toBigInteger(), P_2_64));
+    return create(toBigInteger().modPow(exponent.toBigInteger(), P_2_64).longValue());
   }
 
   @Override
   public UInt64 pow(long exponent) {
-    return UInt64.valueOf(toBigInteger().modPow(BigInteger.valueOf(exponent), P_2_64));
+    return create(toBigInteger().modPow(BigInteger.valueOf(exponent), P_2_64).longValue());
   }
 
   @Override
@@ -409,7 +291,7 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (modulus.isZero()) {
       throw new ArithmeticException("mod by zero");
     }
-    return UInt64.valueOf(toBigInteger().mod(modulus.toBigInteger()));
+    return create(toBigInteger().mod(modulus.toBigInteger()).longValue());
   }
 
   @Override
@@ -420,21 +302,7 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (modulus < 0) {
       throw new ArithmeticException("mod by negative");
     }
-    if (isPowerOf2(modulus)) {
-      int log2 = log2(modulus);
-      int d = log2 / 32;
-      int s = log2 % 32;
-      assert (d == 0 || d == 1);
-
-      int[] result = new int[INTS_SIZE];
-      // Mask the byte at d to only include the s right-most bits
-      result[INTS_SIZE - 1 - d] = this.ints[INTS_SIZE - 1 - d] & ~(0xFFFFFFFF << s);
-      if (d != 0) {
-        result[INTS_SIZE - 1] = this.ints[INTS_SIZE - 1];
-      }
-      return new UInt64(result);
-    }
-    return UInt64.valueOf(toBigInteger().mod(BigInteger.valueOf(modulus)));
+    return create(this.value % modulus);
   }
 
   /**
@@ -446,11 +314,10 @@ public final class UInt64 implements UInt64Value<UInt64> {
    * @return The result of a bit-wise AND.
    */
   public UInt64 and(UInt64 value) {
-    int result[] = new int[INTS_SIZE];
-    for (int i = INTS_SIZE - 1; i >= 0; --i) {
-      result[i] = this.ints[i] & value.ints[i];
+    if (this.value == 0 || value.value == 0) {
+      return ZERO;
     }
-    return new UInt64(result);
+    return create(this.value & value.value);
   }
 
   /**
@@ -458,19 +325,20 @@ public final class UInt64 implements UInt64Value<UInt64> {
    *
    * If this value and the supplied value are different lengths, then the shorter will be zero-padded to the left.
    *
-   * @param bytes The bytes to perform the operation with.
-   * @return The result of a bit-wise AND.
+   * @param bytes the bytes to perform the operation with
+   * @return the result of a bit-wise AND
+   * @throws IllegalArgumentException if more than 8 bytes are supplied
    */
   public UInt64 and(Bytes bytes) {
-    int result[] = new int[INTS_SIZE];
-    for (int i = INTS_SIZE - 1, j = 28; i >= 0; --i, j -= 4) {
-      int other = ((int) bytes.get(j) & 0xFF) << 24;
-      other |= ((int) bytes.get(j + 1) & 0xFF) << 16;
-      other |= ((int) bytes.get(i + 2) & 0xFF) << 8;
-      other |= ((int) bytes.get(i + 3) & 0xFF);
-      result[i] = this.ints[i] & other;
+    checkArgument(bytes.size() <= 8, "and with more than 8 bytes");
+    if (this.value == 0) {
+      return ZERO;
     }
-    return new UInt64(result);
+    long value = bytes.toLong();
+    if (value == 0) {
+      return ZERO;
+    }
+    return create(this.value & value);
   }
 
   /**
@@ -482,11 +350,7 @@ public final class UInt64 implements UInt64Value<UInt64> {
    * @return The result of a bit-wise OR.
    */
   public UInt64 or(UInt64 value) {
-    int result[] = new int[INTS_SIZE];
-    for (int i = INTS_SIZE - 1; i >= 0; --i) {
-      result[i] = this.ints[i] | value.ints[i];
-    }
-    return new UInt64(result);
+    return create(this.value | value.value);
   }
 
   /**
@@ -498,14 +362,8 @@ public final class UInt64 implements UInt64Value<UInt64> {
    * @return The result of a bit-wise OR.
    */
   public UInt64 or(Bytes bytes) {
-    int result[] = new int[INTS_SIZE];
-    for (int i = INTS_SIZE - 1, j = 28; i >= 0; --i, j -= 4) {
-      result[i] = this.ints[i] | (((int) bytes.get(j) & 0xFF) << 24);
-      result[i] |= ((int) bytes.get(j + 1) & 0xFF) << 16;
-      result[i] |= ((int) bytes.get(j + 2) & 0xFF) << 8;
-      result[i] |= ((int) bytes.get(j + 3) & 0xFF);
-    }
-    return new UInt64(result);
+    checkArgument(bytes.size() <= 8, "or with more than 8 bytes");
+    return create(this.value | bytes.toLong());
   }
 
   /**
@@ -517,11 +375,7 @@ public final class UInt64 implements UInt64Value<UInt64> {
    * @return The result of a bit-wise XOR.
    */
   public UInt64 xor(UInt64 value) {
-    int result[] = new int[INTS_SIZE];
-    for (int i = INTS_SIZE - 1; i >= 0; --i) {
-      result[i] = this.ints[i] ^ value.ints[i];
-    }
-    return new UInt64(result);
+    return create(this.value ^ value.value);
   }
 
   /**
@@ -533,14 +387,8 @@ public final class UInt64 implements UInt64Value<UInt64> {
    * @return The result of a bit-wise XOR.
    */
   public UInt64 xor(Bytes bytes) {
-    int result[] = new int[INTS_SIZE];
-    for (int i = INTS_SIZE - 1, j = 28; i >= 0; --i, j -= 4) {
-      result[i] = this.ints[i] ^ (((int) bytes.get(j) & 0xFF) << 24);
-      result[i] ^= ((int) bytes.get(j + 1) & 0xFF) << 16;
-      result[i] ^= ((int) bytes.get(j + 2) & 0xFF) << 8;
-      result[i] ^= ((int) bytes.get(j + 3) & 0xFF);
-    }
-    return new UInt64(result);
+    checkArgument(bytes.size() <= 8, "xor with more than 8 bytes");
+    return create(this.value ^ bytes.toLong());
   }
 
   /**
@@ -549,11 +397,7 @@ public final class UInt64 implements UInt64Value<UInt64> {
    * @return The result of a bit-wise NOT.
    */
   public UInt64 not() {
-    int result[] = new int[INTS_SIZE];
-    for (int i = INTS_SIZE - 1; i >= 0; --i) {
-      result[i] = ~(this.ints[i]);
-    }
-    return new UInt64(result);
+    return create(~this.value);
   }
 
   /**
@@ -569,23 +413,7 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (distance >= 64) {
       return ZERO;
     }
-    int result[] = new int[INTS_SIZE];
-    int d = distance / 32;
-    int s = distance % 32;
-
-    int resIdx = INTS_SIZE;
-    if (s == 0) {
-      for (int i = INTS_SIZE - d; i > 0;) {
-        result[--resIdx] = this.ints[--i];
-      }
-    } else {
-      for (int i = INTS_SIZE - 1 - d; i >= 0; i--) {
-        int leftSide = this.ints[i] >>> s;
-        int rightSide = (i == 0) ? 0 : this.ints[i - 1] << (32 - s);
-        result[--resIdx] = (leftSide | rightSide);
-      }
-    }
-    return new UInt64(result);
+    return create(this.value >>> distance);
   }
 
   /**
@@ -601,23 +429,7 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (distance >= 64) {
       return ZERO;
     }
-    int result[] = new int[INTS_SIZE];
-    int d = distance / 32;
-    int s = distance % 32;
-
-    int resIdx = 0;
-    if (s == 0) {
-      for (int i = d; i < INTS_SIZE;) {
-        result[resIdx++] = this.ints[i++];
-      }
-    } else {
-      for (int i = d; i < INTS_SIZE; ++i) {
-        int leftSide = this.ints[i] << s;
-        int rightSide = (i == INTS_SIZE - 1) ? 0 : (this.ints[i + 1] >>> (32 - s));
-        result[resIdx++] = (leftSide | rightSide);
-      }
-    }
-    return new UInt64(result);
+    return create(this.value << distance);
   }
 
   @Override
@@ -629,43 +441,22 @@ public final class UInt64 implements UInt64Value<UInt64> {
       return false;
     }
     UInt64 other = (UInt64) object;
-    for (int i = 0; i < INTS_SIZE; ++i) {
-      if (this.ints[i] != other.ints[i]) {
-        return false;
-      }
-    }
-    return true;
+    return this.value == other.value;
   }
 
   @Override
   public int hashCode() {
-    int result = 1;
-    for (int i = 0; i < INTS_SIZE; ++i) {
-      result = 31 * result + this.ints[i];
-    }
-    return result;
+    return Long.hashCode(this.value);
   }
 
   @Override
   public int compareTo(UInt64 other) {
-    for (int i = 0; i < INTS_SIZE; ++i) {
-      int cmp = Long.compare(((long) this.ints[i]) & LONG_MASK, ((long) other.ints[i]) & LONG_MASK);
-      if (cmp != 0) {
-        return cmp;
-      }
-    }
-    return 0;
+    return Long.compareUnsigned(this.value, other.value);
   }
 
   @Override
   public boolean fitsInt() {
-    for (int i = 0; i < INTS_SIZE - 1; i++) {
-      if (this.ints[i] != 0) {
-        return false;
-      }
-    }
-    // Lastly, the left-most byte of the int must not start with a 1.
-    return this.ints[INTS_SIZE - 1] >= 0;
+    return this.value >= 0 && this.value <= Integer.MAX_VALUE;
   }
 
   @Override
@@ -673,18 +464,12 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (!fitsInt()) {
       throw new ArithmeticException("Value does not fit a 4 byte int");
     }
-    return this.ints[INTS_SIZE - 1];
+    return (int) this.value;
   }
 
   @Override
   public boolean fitsLong() {
-    for (int i = 0; i < INTS_SIZE - 2; i++) {
-      if (this.ints[i] != 0) {
-        return false;
-      }
-    }
-    // Lastly, the left-most byte of the int must not start with a 1.
-    return this.ints[INTS_SIZE - 2] >= 0;
+    return this.value >= 0;
   }
 
   @Override
@@ -692,7 +477,7 @@ public final class UInt64 implements UInt64Value<UInt64> {
     if (!fitsLong()) {
       throw new ArithmeticException("Value does not fit a 8 byte long");
     }
-    return (((long) this.ints[INTS_SIZE - 2]) << 32) | (((long) (this.ints[INTS_SIZE - 1])) & LONG_MASK);
+    return this.value;
   }
 
   @Override
@@ -702,13 +487,15 @@ public final class UInt64 implements UInt64Value<UInt64> {
 
   @Override
   public BigInteger toBigInteger() {
-    byte mag[] = new byte[8];
-    for (int i = 0, j = 0; i < INTS_SIZE; ++i) {
-      mag[j++] = (byte) (this.ints[i] >>> 24);
-      mag[j++] = (byte) ((this.ints[i] >>> 16) & 0xFF);
-      mag[j++] = (byte) ((this.ints[i] >>> 8) & 0xFF);
-      mag[j++] = (byte) (this.ints[i] & 0xFF);
-    }
+    byte[] mag = new byte[8];
+    mag[0] = (byte) ((this.value >>> 56) & 0xFF);
+    mag[1] = (byte) ((this.value >>> 48) & 0xFF);
+    mag[2] = (byte) ((this.value >>> 40) & 0xFF);
+    mag[3] = (byte) ((this.value >>> 32) & 0xFF);
+    mag[4] = (byte) ((this.value >>> 24) & 0xFF);
+    mag[5] = (byte) ((this.value >>> 16) & 0xFF);
+    mag[6] = (byte) ((this.value >>> 8) & 0xFF);
+    mag[7] = (byte) (this.value & 0xFF);
     return new BigInteger(1, mag);
   }
 
@@ -720,65 +507,51 @@ public final class UInt64 implements UInt64Value<UInt64> {
   @Override
   public Bytes toBytes() {
     MutableBytes bytes = MutableBytes.create(8);
-    for (int i = 0, j = 0; i < INTS_SIZE; ++i, j += 4) {
-      bytes.setInt(j, this.ints[i]);
-    }
+    bytes.setLong(0, this.value);
     return bytes;
   }
 
   @Override
   public Bytes toMinimalBytes() {
-    int i = 0;
-    while (i < INTS_SIZE && this.ints[i] == 0) {
-      ++i;
-    }
-    if (i == INTS_SIZE) {
-      return Bytes.EMPTY;
-    }
-    int firstIntBytes = 4 - (Integer.numberOfLeadingZeros(this.ints[i]) / 8);
-    int totalBytes = firstIntBytes + ((INTS_SIZE - (i + 1)) * 4);
-    MutableBytes bytes = MutableBytes.create(totalBytes);
+    int requiredBytes = 8 - (Long.numberOfLeadingZeros(this.value) / 8);
+    MutableBytes bytes = MutableBytes.create(requiredBytes);
     int j = 0;
-    switch (firstIntBytes) {
+    switch (requiredBytes) {
+      case 8:
+        bytes.set(j++, (byte) (this.value >>> 56));
+        // fall through
+      case 7:
+        bytes.set(j++, (byte) ((this.value >>> 48) & 0xFF));
+        // fall through
+      case 6:
+        bytes.set(j++, (byte) ((this.value >>> 40) & 0xFF));
+        // fall through
+      case 5:
+        bytes.set(j++, (byte) ((this.value >>> 32) & 0xFF));
+        // fall through
       case 4:
-        bytes.set(j++, (byte) (this.ints[i] >>> 24));
+        bytes.set(j++, (byte) ((this.value >>> 24) & 0xFF));
         // fall through
       case 3:
-        bytes.set(j++, (byte) ((this.ints[i] >>> 16) & 0xFF));
+        bytes.set(j++, (byte) ((this.value >>> 16) & 0xFF));
         // fall through
       case 2:
-        bytes.set(j++, (byte) ((this.ints[i] >>> 8) & 0xFF));
+        bytes.set(j++, (byte) ((this.value >>> 8) & 0xFF));
         // fall through
       case 1:
-        bytes.set(j++, (byte) (this.ints[i] & 0xFF));
-    }
-    ++i;
-    for (; i < INTS_SIZE; ++i, j += 4) {
-      bytes.setInt(j, this.ints[i]);
+        bytes.set(j, (byte) (this.value & 0xFF));
     }
     return bytes;
   }
 
   @Override
   public int numberOfLeadingZeros() {
-    for (int i = 0; i < INTS_SIZE; i++) {
-      if (this.ints[i] == 0) {
-        continue;
-      }
-      return (i * 32) + Integer.numberOfLeadingZeros(this.ints[i]);
-    }
-    return 64;
+    return Long.numberOfLeadingZeros(this.value);
   }
 
   @Override
   public int bitLength() {
-    for (int i = 0; i < INTS_SIZE; i++) {
-      if (this.ints[i] == 0) {
-        continue;
-      }
-      return (INTS_SIZE * 32) - (i * 32) - Integer.numberOfLeadingZeros(this.ints[i]);
-    }
-    return 0;
+    return 64 - Long.numberOfLeadingZeros(this.value);
   }
 
   private static boolean isPowerOf2(long n) {

--- a/units/src/main/java/net/consensys/cava/units/bigints/UInt64Value.java
+++ b/units/src/main/java/net/consensys/cava/units/bigints/UInt64Value.java
@@ -21,8 +21,7 @@ import java.math.BigInteger;
  * Represents a 64-bit (8 bytes) unsigned integer value.
  *
  * <p>
- * A {@link UInt64Value} is an unsigned integer value stored with 8 bytes, so whose value can range between 0 and
- * 2^64-1.
+ * A {@link UInt64Value} is an unsigned integer value whose value can range between 0 and 2^64-1.
  *
  * <p>
  * This interface defines operations for value types with a 64-bit precision range. The methods provided by this
@@ -58,14 +57,14 @@ public interface UInt64Value<T extends UInt64Value<T>> extends Comparable<T> {
   /**
    * Returns a value that is {@code (this + value)}.
    *
-   * @param value The amount to be added to this value.
+   * @param value the amount to be added to this value
    * @return {@code this + value}
    * @throws ArithmeticException if the result of the addition overflows
    */
-  default T tryAdd(T value) {
+  default T addExact(T value) {
     T result = add(value);
-    if (this.compareTo(result) > 0) {
-      throw new ArithmeticException("Value overflowed");
+    if (compareTo(result) > 0) {
+      throw new ArithmeticException("UInt64 overflow");
     }
     return result;
   }
@@ -81,14 +80,14 @@ public interface UInt64Value<T extends UInt64Value<T>> extends Comparable<T> {
   /**
    * Returns a value that is {@code (this + value)}.
    *
-   * @param value The amount to be added to this value.
+   * @param value the amount to be added to this value
    * @return {@code this + value}
    * @throws ArithmeticException if the result of the addition overflows
    */
-  default T tryAdd(long value) {
+  default T addExact(long value) {
     T result = add(value);
-    if (this.compareTo(result) > 0) {
-      throw new ArithmeticException("Value overflowed");
+    if ((value > 0 && compareTo(result) > 0) || (value < 0 && compareTo(result) < 0)) {
+      throw new ArithmeticException("UInt64 overflow");
     }
     return result;
   }
@@ -134,14 +133,14 @@ public interface UInt64Value<T extends UInt64Value<T>> extends Comparable<T> {
   /**
    * Returns a value that is {@code (this - value)}.
    *
-   * @param value The amount to be subtracted to this value.
+   * @param value the amount to be subtracted to this value
    * @return {@code this - value}
-   * @throws ArithmeticException if the result of the addition underflows
+   * @throws ArithmeticException if the result of the subtraction overflows
    */
-  default T trySubtract(T value) {
+  default T subtractExact(T value) {
     T result = subtract(value);
-    if (this.compareTo(result) < 0) {
-      throw new ArithmeticException("Value underflowed");
+    if (compareTo(result) < 0) {
+      throw new ArithmeticException("UInt64 overflow");
     }
     return result;
   }
@@ -157,14 +156,14 @@ public interface UInt64Value<T extends UInt64Value<T>> extends Comparable<T> {
   /**
    * Returns a value that is {@code (this - value)}.
    *
-   * @param value The amount to be subtracted to this value.
+   * @param value the amount to be subtracted to this value
    * @return {@code this - value}
-   * @throws ArithmeticException if the result of the addition underflows
+   * @throws ArithmeticException if the result of the subtraction overflows
    */
-  default T trySubtract(long value) {
+  default T subtractExact(long value) {
     T result = subtract(value);
-    if (this.compareTo(result) < 0) {
-      throw new ArithmeticException("Value underflowed");
+    if ((value > 0 && compareTo(result) < 0) || (value < 0 && compareTo(result) > 0)) {
+      throw new ArithmeticException("UInt64 overflow");
     }
     return result;
   }

--- a/units/src/test/java/net/consensys/cava/units/bigints/BaseUInt256ValueTest.java
+++ b/units/src/test/java/net/consensys/cava/units/bigints/BaseUInt256ValueTest.java
@@ -856,6 +856,47 @@ class BaseUInt256ValueTest {
         Arguments.of(hv("0x100000000"), 33));
   }
 
+  @ParameterizedTest
+  @MethodSource("addExactProvider")
+  void addExact(Value value, Value operand) {
+    assertThrows(ArithmeticException.class, () -> value.addExact(operand));
+  }
+
+  private static Stream<Arguments> addExactProvider() {
+    return Stream.of(Arguments.of(Value.MAX_VALUE, v(1)), Arguments.of(Value.MAX_VALUE, Value.MAX_VALUE));
+  }
+
+  @ParameterizedTest
+  @MethodSource("addExactLongProvider")
+  void addExactLong(Value value, long operand) {
+    assertThrows(ArithmeticException.class, () -> value.addExact(operand));
+  }
+
+  private static Stream<Arguments> addExactLongProvider() {
+    return Stream
+        .of(Arguments.of(Value.MAX_VALUE, 3), Arguments.of(Value.MAX_VALUE, Long.MAX_VALUE), Arguments.of(v(0), -1));
+  }
+
+  @ParameterizedTest
+  @MethodSource("subtractExactProvider")
+  void subtractExact(Value value, Value operand) {
+    assertThrows(ArithmeticException.class, () -> value.subtractExact(operand));
+  }
+
+  private static Stream<Arguments> subtractExactProvider() {
+    return Stream.of(Arguments.of(v(0), v(1)), Arguments.of(v(0), Value.MAX_VALUE));
+  }
+
+  @ParameterizedTest
+  @MethodSource("subtractExactLongProvider")
+  void subtractExactLong(Value value, long operand) {
+    assertThrows(ArithmeticException.class, () -> value.subtractExact(operand));
+  }
+
+  private static Stream<Arguments> subtractExactLongProvider() {
+    return Stream.of(Arguments.of(v(0), 1), Arguments.of(v(0), Long.MAX_VALUE), Arguments.of(Value.MAX_VALUE, -1));
+  }
+
   private void assertValueEquals(Value expected, Value actual) {
     String msg = String.format("Expected %s but got %s", expected.toHexString(), actual.toHexString());
     assertEquals(expected, actual, msg);

--- a/units/src/test/java/net/consensys/cava/units/bigints/BaseUInt384ValueTest.java
+++ b/units/src/test/java/net/consensys/cava/units/bigints/BaseUInt384ValueTest.java
@@ -765,6 +765,47 @@ class BaseUInt384ValueTest {
         Arguments.of(hv("0x100000000"), 33));
   }
 
+  @ParameterizedTest
+  @MethodSource("addExactProvider")
+  void addExact(Value value, Value operand) {
+    assertThrows(ArithmeticException.class, () -> value.addExact(operand));
+  }
+
+  private static Stream<Arguments> addExactProvider() {
+    return Stream.of(Arguments.of(Value.MAX_VALUE, v(1)), Arguments.of(Value.MAX_VALUE, Value.MAX_VALUE));
+  }
+
+  @ParameterizedTest
+  @MethodSource("addExactLongProvider")
+  void addExactLong(Value value, long operand) {
+    assertThrows(ArithmeticException.class, () -> value.addExact(operand));
+  }
+
+  private static Stream<Arguments> addExactLongProvider() {
+    return Stream
+        .of(Arguments.of(Value.MAX_VALUE, 3), Arguments.of(Value.MAX_VALUE, Long.MAX_VALUE), Arguments.of(v(0), -1));
+  }
+
+  @ParameterizedTest
+  @MethodSource("subtractExactProvider")
+  void subtractExact(Value value, Value operand) {
+    assertThrows(ArithmeticException.class, () -> value.subtractExact(operand));
+  }
+
+  private static Stream<Arguments> subtractExactProvider() {
+    return Stream.of(Arguments.of(v(0), v(1)), Arguments.of(v(0), Value.MAX_VALUE));
+  }
+
+  @ParameterizedTest
+  @MethodSource("subtractExactLongProvider")
+  void subtractExactLong(Value value, long operand) {
+    assertThrows(ArithmeticException.class, () -> value.subtractExact(operand));
+  }
+
+  private static Stream<Arguments> subtractExactLongProvider() {
+    return Stream.of(Arguments.of(v(0), 1), Arguments.of(v(0), Long.MAX_VALUE), Arguments.of(Value.MAX_VALUE, -1));
+  }
+
   private void assertValueEquals(Value expected, Value actual) {
     String msg = String.format("Expected %s but got %s", expected.toHexString(), actual.toHexString());
     assertEquals(expected, actual, msg);

--- a/units/src/test/java/net/consensys/cava/units/bigints/BaseUInt64ValueTest.java
+++ b/units/src/test/java/net/consensys/cava/units/bigints/BaseUInt64ValueTest.java
@@ -697,6 +697,47 @@ class BaseUInt64ValueTest {
         Arguments.of(hv("0x100000000"), 33));
   }
 
+  @ParameterizedTest
+  @MethodSource("addExactProvider")
+  void addExact(Value value, Value operand) {
+    assertThrows(ArithmeticException.class, () -> value.addExact(operand));
+  }
+
+  private static Stream<Arguments> addExactProvider() {
+    return Stream.of(Arguments.of(Value.MAX_VALUE, v(1)), Arguments.of(Value.MAX_VALUE, Value.MAX_VALUE));
+  }
+
+  @ParameterizedTest
+  @MethodSource("addExactLongProvider")
+  void addExactLong(Value value, long operand) {
+    assertThrows(ArithmeticException.class, () -> value.addExact(operand));
+  }
+
+  private static Stream<Arguments> addExactLongProvider() {
+    return Stream
+        .of(Arguments.of(Value.MAX_VALUE, 3), Arguments.of(Value.MAX_VALUE, Long.MAX_VALUE), Arguments.of(v(0), -1));
+  }
+
+  @ParameterizedTest
+  @MethodSource("subtractExactProvider")
+  void subtractExact(Value value, Value operand) {
+    assertThrows(ArithmeticException.class, () -> value.subtractExact(operand));
+  }
+
+  private static Stream<Arguments> subtractExactProvider() {
+    return Stream.of(Arguments.of(v(0), v(1)), Arguments.of(v(0), Value.MAX_VALUE));
+  }
+
+  @ParameterizedTest
+  @MethodSource("subtractExactLongProvider")
+  void subtractExactLong(Value value, long operand) {
+    assertThrows(ArithmeticException.class, () -> value.subtractExact(operand));
+  }
+
+  private static Stream<Arguments> subtractExactLongProvider() {
+    return Stream.of(Arguments.of(v(0), 1), Arguments.of(v(0), Long.MAX_VALUE), Arguments.of(Value.MAX_VALUE, -1));
+  }
+
   private void assertValueEquals(Value expected, Value actual) {
     String msg = String.format("Expected %s but got %s", expected.toHexString(), actual.toHexString());
     assertEquals(expected, actual, msg);

--- a/units/src/test/java/net/consensys/cava/units/bigints/UInt256Test.java
+++ b/units/src/test/java/net/consensys/cava/units/bigints/UInt256Test.java
@@ -39,6 +39,19 @@ class UInt256Test {
     return UInt256.fromHexString(s);
   }
 
+  @Test
+  void valueOfLong() {
+    assertThrows(IllegalArgumentException.class, () -> UInt256.valueOf(-1));
+    assertThrows(IllegalArgumentException.class, () -> UInt256.valueOf(Long.MIN_VALUE));
+    assertThrows(IllegalArgumentException.class, () -> UInt256.valueOf(~0L));
+  }
+
+  @Test
+  void valueOfBigInteger() {
+    assertThrows(IllegalArgumentException.class, () -> UInt256.valueOf(BigInteger.valueOf(-1)));
+    assertThrows(IllegalArgumentException.class, () -> UInt256.valueOf(BigInteger.valueOf(2).pow(256)));
+  }
+
   @ParameterizedTest
   @MethodSource("addProvider")
   void add(UInt256 v1, UInt256 v2, UInt256 expected) {
@@ -865,22 +878,51 @@ class UInt256Test {
         Arguments.of(hv("0x100000000"), 33));
   }
 
+  @ParameterizedTest
+  @MethodSource("addExactProvider")
+  void addExact(UInt256 value, UInt256 operand) {
+    assertThrows(ArithmeticException.class, () -> value.addExact(operand));
+  }
+
+  private static Stream<Arguments> addExactProvider() {
+    return Stream.of(Arguments.of(UInt256.MAX_VALUE, v(1)), Arguments.of(UInt256.MAX_VALUE, UInt256.MAX_VALUE));
+  }
+
+  @ParameterizedTest
+  @MethodSource("addExactLongProvider")
+  void addExactLong(UInt256 value, long operand) {
+    assertThrows(ArithmeticException.class, () -> value.addExact(operand));
+  }
+
+  private static Stream<Arguments> addExactLongProvider() {
+    return Stream.of(
+        Arguments.of(UInt256.MAX_VALUE, 3),
+        Arguments.of(UInt256.MAX_VALUE, Long.MAX_VALUE),
+        Arguments.of(v(0), -1));
+  }
+
+  @ParameterizedTest
+  @MethodSource("subtractExactProvider")
+  void subtractExact(UInt256 value, UInt256 operand) {
+    assertThrows(ArithmeticException.class, () -> value.subtractExact(operand));
+  }
+
+  private static Stream<Arguments> subtractExactProvider() {
+    return Stream.of(Arguments.of(v(0), v(1)), Arguments.of(v(0), UInt256.MAX_VALUE));
+  }
+
+  @ParameterizedTest
+  @MethodSource("subtractExactLongProvider")
+  void subtractExactLong(UInt256 value, long operand) {
+    assertThrows(ArithmeticException.class, () -> value.subtractExact(operand));
+  }
+
+  private static Stream<Arguments> subtractExactLongProvider() {
+    return Stream.of(Arguments.of(v(0), 1), Arguments.of(v(0), Long.MAX_VALUE), Arguments.of(UInt256.MAX_VALUE, -1));
+  }
+
   private void assertValueEquals(UInt256 expected, UInt256 actual) {
     String msg = String.format("Expected %s but got %s", expected.toHexString(), actual.toHexString());
     assertEquals(expected, actual, msg);
-  }
-
-  @Test
-  void testTryAdd() {
-    assertThrows(ArithmeticException.class, () -> UInt256.MAX_VALUE.tryAdd(3));
-
-    assertThrows(ArithmeticException.class, () -> UInt256.MAX_VALUE.tryAdd(UInt256.MAX_VALUE));
-  }
-
-  @Test
-  void testTrySubtract() {
-    assertThrows(ArithmeticException.class, () -> UInt256.valueOf(3).trySubtract(5));
-
-    assertThrows(ArithmeticException.class, () -> UInt256.MIN_VALUE.trySubtract(UInt256.MAX_VALUE));
   }
 }

--- a/units/src/test/java/net/consensys/cava/units/bigints/UInt384Test.java
+++ b/units/src/test/java/net/consensys/cava/units/bigints/UInt384Test.java
@@ -39,6 +39,19 @@ class UInt384Test {
     return UInt384.fromHexString(s);
   }
 
+  @Test
+  void valueOfLong() {
+    assertThrows(IllegalArgumentException.class, () -> UInt384.valueOf(-1));
+    assertThrows(IllegalArgumentException.class, () -> UInt384.valueOf(Long.MIN_VALUE));
+    assertThrows(IllegalArgumentException.class, () -> UInt384.valueOf(~0L));
+  }
+
+  @Test
+  void valueOfBigInteger() {
+    assertThrows(IllegalArgumentException.class, () -> UInt384.valueOf(BigInteger.valueOf(-1)));
+    assertThrows(IllegalArgumentException.class, () -> UInt384.valueOf(BigInteger.valueOf(2).pow(384)));
+  }
+
   @ParameterizedTest
   @MethodSource("addProvider")
   void add(UInt384 v1, UInt384 v2, UInt384 expected) {
@@ -884,22 +897,51 @@ class UInt384Test {
         Arguments.of(hv("0x100000000"), 33));
   }
 
+  @ParameterizedTest
+  @MethodSource("addExactProvider")
+  void addExact(UInt384 value, UInt384 operand) {
+    assertThrows(ArithmeticException.class, () -> value.addExact(operand));
+  }
+
+  private static Stream<Arguments> addExactProvider() {
+    return Stream.of(Arguments.of(UInt384.MAX_VALUE, v(1)), Arguments.of(UInt384.MAX_VALUE, UInt384.MAX_VALUE));
+  }
+
+  @ParameterizedTest
+  @MethodSource("addExactLongProvider")
+  void addExactLong(UInt384 value, long operand) {
+    assertThrows(ArithmeticException.class, () -> value.addExact(operand));
+  }
+
+  private static Stream<Arguments> addExactLongProvider() {
+    return Stream.of(
+        Arguments.of(UInt384.MAX_VALUE, 3),
+        Arguments.of(UInt384.MAX_VALUE, Long.MAX_VALUE),
+        Arguments.of(v(0), -1));
+  }
+
+  @ParameterizedTest
+  @MethodSource("subtractExactProvider")
+  void subtractExact(UInt384 value, UInt384 operand) {
+    assertThrows(ArithmeticException.class, () -> value.subtractExact(operand));
+  }
+
+  private static Stream<Arguments> subtractExactProvider() {
+    return Stream.of(Arguments.of(v(0), v(1)), Arguments.of(v(0), UInt384.MAX_VALUE));
+  }
+
+  @ParameterizedTest
+  @MethodSource("subtractExactLongProvider")
+  void subtractExactLong(UInt384 value, long operand) {
+    assertThrows(ArithmeticException.class, () -> value.subtractExact(operand));
+  }
+
+  private static Stream<Arguments> subtractExactLongProvider() {
+    return Stream.of(Arguments.of(v(0), 1), Arguments.of(v(0), Long.MAX_VALUE), Arguments.of(UInt384.MAX_VALUE, -1));
+  }
+
   private void assertValueEquals(UInt384 expected, UInt384 actual) {
     String msg = String.format("Expected %s but got %s", expected.toHexString(), actual.toHexString());
     assertEquals(expected, actual, msg);
-  }
-
-  @Test
-  void testTryAdd() {
-    assertThrows(ArithmeticException.class, () -> UInt384.MAX_VALUE.tryAdd(3));
-
-    assertThrows(ArithmeticException.class, () -> UInt384.MAX_VALUE.tryAdd(UInt384.MAX_VALUE));
-  }
-
-  @Test
-  void testTrySubtract() {
-    assertThrows(ArithmeticException.class, () -> UInt384.valueOf(3).trySubtract(5));
-
-    assertThrows(ArithmeticException.class, () -> UInt384.MIN_VALUE.trySubtract(UInt384.MAX_VALUE));
   }
 }


### PR DESCRIPTION
Also improve boundary checking of `addExact(long)`, `subtractExact(long)` and `valueOf(BigInteger)`