### PR TITLE
Support v values longer than one byte

### DIFF
--- a/eth/src/main/java/net/consensys/cava/eth/Transaction.java
+++ b/eth/src/main/java/net/consensys/cava/eth/Transaction.java
@@ -89,7 +89,7 @@ public final class Transaction {
     }
     Wei value = Wei.valueOf(reader.readUInt256());
     Bytes payload = reader.readValue();
-    byte encodedV = reader.readByte();
+    int encodedV = reader.readInt();
     Bytes rbytes = reader.readValue();
     if (rbytes.size() > 32) {
       throw new RLPException("r-value of the signature is " + rbytes.size() + ", it should be at most 32 bytes");
@@ -104,12 +104,12 @@ public final class Transaction {
       throw new RLPException("Additional bytes present at the end of the encoding");
     }
 
-    Byte v = null;
+    byte v;
     Integer chainId = null;
 
-    if ((int) encodedV == V_BASE || (int) encodedV == (V_BASE + 1)) {
-      v = (byte) ((int) encodedV - V_BASE);
-    } else if (((int) encodedV) > 35) {
+    if (encodedV == V_BASE || encodedV == (V_BASE + 1)) {
+      v = (byte) (encodedV - V_BASE);
+    } else if (encodedV > 35) {
       chainId = (encodedV - 35) / 2;
       v = (byte) (encodedV - (2 * chainId + 35));
     } else {
@@ -394,9 +394,9 @@ public final class Transaction {
     writer.writeValue(payload);
     if (chainId != null) {
       int v = signature.v() + V_BASE + 8 + chainId * 2;
-      writer.writeByte((byte) v);
+      writer.writeInt(v);
     } else {
-      writer.writeByte((byte) ((int) signature.v() + V_BASE));
+      writer.writeInt((int) signature.v() + V_BASE);
     }
     writer.writeBigInteger(signature.r());
     writer.writeBigInteger(signature.s());

--- a/eth/src/test/java/net/consensys/cava/eth/TransactionTest.java
+++ b/eth/src/test/java/net/consensys/cava/eth/TransactionTest.java
@@ -60,4 +60,20 @@ class TransactionTest {
     Transaction tx = generateTransaction(keyPair);
     assertEquals(sender, tx.sender());
   }
+
+  @Test
+  void supportVMoreThanOneByte() {
+    Transaction tx = new Transaction(
+        UInt256.valueOf(0),
+        Wei.valueOf(BigInteger.valueOf(5L)),
+        Gas.valueOf(10L),
+        Address.fromBytes(Bytes.fromHexString("0x0102030405060708091011121314151617181920")),
+        Wei.valueOf(10L),
+        Bytes.of(1, 2, 3, 4),
+        SECP256K1.KeyPair.random(),
+        16 * 16 * 3);
+    Bytes bytes = tx.toBytes();
+    Transaction read = Transaction.fromBytes(bytes);
+    assertEquals(16 * 16 * 3, (int) read.chainId());
+  }
 }


### PR DESCRIPTION
This is an edge case of transactions. We allow v to encode the chainId per EIP-155. Because of that change, V is now possibly multiple bytes. For now we allow values as big as four bytes.
This is inspired by this PR: https://github.com/ethereumjs/ethereumjs-tx/pull/57/files