### PR TITLE
Give SSZ#merkleHash Public Visibility for Compatibility

### DIFF
--- a/ssz/src/main/java/net/consensys/cava/ssz/SSZ.java
+++ b/ssz/src/main/java/net/consensys/cava/ssz/SSZ.java
@@ -67,10 +67,9 @@ public final class SSZ {
    * Hashes a list of homogeneous values.
    *
    * @param values a list of homogeneous values
-   *
    * @return the merkle hash of the list of values
    */
-  static Bytes merkleHash(List<Bytes> values) {
+  public static Bytes merkleHash(List<Bytes> values) {
     Bytes littleEndianLength = Bytes.ofUnsignedInt(values.size(), LITTLE_ENDIAN);
     Bytes32 valuesLength = Bytes32.rightPad(littleEndianLength);
 


### PR DESCRIPTION
This PR modifies the visibility of `SSZ#merkleHash` to be public, which allows compatibility and ease of implementation with some versions of the Eth2 Beacon Chain spec. More details are provided in the linked issue.

Resolves #197 