### PR TITLE
Fixes for SSB

### DIFF
--- a/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/SecureScuttlebuttHandshakeClient.java
+++ b/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/SecureScuttlebuttHandshakeClient.java
@@ -265,7 +265,7 @@ public final class SecureScuttlebuttHandshakeClient {
    * @return a clientToServerNonce for use with decrypting messages from the server.
    */
   Bytes serverToClientNonce() {
-    return HMACSHA512256.authenticate(longTermKeyPair.publicKey().bytes(), networkIdentifier).slice(0, 24);
+    return HMACSHA512256.authenticate(ephemeralKeyPair.publicKey().bytes(), networkIdentifier).slice(0, 24);
   }
 
   /**

--- a/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/SecureScuttlebuttHandshakeServer.java
+++ b/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/SecureScuttlebuttHandshakeServer.java
@@ -255,7 +255,7 @@ public final class SecureScuttlebuttHandshakeServer {
    * @return a clientToServerNonce for use with decrypting messages from the server.
    */
   Bytes serverToClientNonce() {
-    return HMACSHA512256.authenticate(clientLongTermPublicKey.bytes(), networkIdentifier).slice(0, 24);
+    return HMACSHA512256.authenticate(clientEphemeralPublicKey.bytes(), networkIdentifier).slice(0, 24);
   }
 
   /**

--- a/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/SecureScuttlebuttStreamClient.java
+++ b/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/SecureScuttlebuttStreamClient.java
@@ -35,10 +35,11 @@ public interface SecureScuttlebuttStreamClient {
   Bytes sendGoodbyeToServer();
 
   /**
-   * Decrypts a message from the server
+   * Adds message bytes to the reader stream, returning the bytes that could be decrypted.
    * 
    * @param message the message to decrypt
-   * @return the message, decrypted and ready for consumption
+   * @return the message, decrypted and ready for consumption, or null if the message provided were an incomplete
+   *         message.
    * @throws StreamException if the message cannot be decrypted
    */
   Bytes readFromServer(Bytes message);

--- a/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/SecureScuttlebuttStreamServer.java
+++ b/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/SecureScuttlebuttStreamServer.java
@@ -46,10 +46,10 @@ public interface SecureScuttlebuttStreamServer {
   Bytes sendGoodbyeToClient();
 
   /**
-   * Decrypts a message from the client
+   * Adds message bytes to the reader stream, returning the bytes that could be decrypted.
    * 
    * @param message the message to decrypt
-   * @return the message, decrypted and ready for consumption
+   * @return the message, decrypted and ready for consumption, or null if the bytes provided were an incomplete message.
    * @throws StreamException if the message cannot be decrypted
    */
   Bytes readFromClient(Bytes message);

--- a/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/vertx/SecureScuttlebuttVertxClient.java
+++ b/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/vertx/SecureScuttlebuttVertxClient.java
@@ -89,6 +89,9 @@ public final class SecureScuttlebuttVertxClient {
           handshakeCounter++;
         } else {
           Bytes message = client.readFromServer(Bytes.wrapBuffer(buffer));
+          if (message == null) {
+            return;
+          }
           if (SecureScuttlebuttStreamServer.isGoodbye(message)) {
             logger.debug("Goodbye received from remote peer");
             socket.close();

--- a/scuttlebutt-rpc/src/test/java/net/consensys/cava/scuttlebutt/rpc/PatchworkIntegrationTest.java
+++ b/scuttlebutt-rpc/src/test/java/net/consensys/cava/scuttlebutt/rpc/PatchworkIntegrationTest.java
@@ -69,9 +69,8 @@ class PatchworkIntegrationTest {
 
     @Override
     public void receivedMessage(Bytes message) {
-
       System.out.println("We received a message?");
-
+      System.out.println(new String(message.toArrayUnsafe(), UTF_8));
     }
 
     @Override


### PR DESCRIPTION
Fix nonce by using ephemeral keys, not long term keys. Make sure to read body size with a mask to read integer as unsigned. Handle chunked messages of length less than the length of a message