### PR TITLE
SecureScuttlebutt: reset buffers if all buffer is consumed

### DIFF
--- a/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/SecureScuttlebuttStream.java
+++ b/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/SecureScuttlebuttStream.java
@@ -84,16 +84,18 @@ final class SecureScuttlebuttStream implements SecureScuttlebuttStreamClient, Se
     while (index < messageWithBuffer.size()) {
       Bytes decryptedMessage = decryptMessage(messageWithBuffer.slice(index), key, nonce);
       if (decryptedMessage == null) {
-        if (isClientToServer) {
-          clientToServerBuffer = messageWithBuffer.slice(index);
-        } else {
-          serverToClientBuffer = messageWithBuffer.slice(index);
-        }
         break;
       }
       decryptedMessages.add(decryptedMessage);
       index += decryptedMessage.size() + 34;
     }
+
+    if (isClientToServer) {
+      clientToServerBuffer = messageWithBuffer.slice(index);
+    } else {
+      serverToClientBuffer = messageWithBuffer.slice(index);
+    }
+
     return Bytes.concatenate(decryptedMessages.toArray(new Bytes[0]));
   }
 

--- a/scuttlebutt-rpc/src/test/java/net/consensys/cava/scuttlebutt/rpc/PatchworkIntegrationTest.java
+++ b/scuttlebutt-rpc/src/test/java/net/consensys/cava/scuttlebutt/rpc/PatchworkIntegrationTest.java
@@ -158,7 +158,7 @@ class PatchworkIntegrationTest {
     AsyncResult<ClientHandler> onConnect =
         secureScuttlebuttVertxClient.connectTo(port, host, publicKey, MyClientHandler::new);
 
-    ClientHandler clientHandler = onConnect.get();
+    MyClientHandler clientHandler = (MyClientHandler) onConnect.get();
     assertTrue(onConnect.isDone());
     assertFalse(onConnect.isCompletedExceptionally());
     Thread.sleep(1000);
@@ -168,7 +168,10 @@ class PatchworkIntegrationTest {
     Bytes rpcRequest = RPCCodec.encodeRequest(rpcRequestBody, RPCFlag.BodyType.JSON);
 
     System.out.println("Attempting RPC request...");
-    ((MyClientHandler) clientHandler).sendMessage(rpcRequest);
+    clientHandler.sendMessage(rpcRequest);
+    for (int i = 0; i < 10; i++) {
+      clientHandler.sendMessage(RPCCodec.encodeRequest(rpcRequestBody, RPCFlag.BodyType.JSON));
+    }
 
     Thread.sleep(10000);
 


### PR DESCRIPTION
Fix happy path of message consumption, and add synchronized blocks so nonces don't lose order.