### PR TITLE
Hand over one complete message to the ClientHandler implementation at a time so that it doesn't have to inspect the headers and calculate how many messages are present

### DIFF
--- a/scuttlebutt-handshake/build.gradle
+++ b/scuttlebutt-handshake/build.gradle
@@ -18,5 +18,7 @@ dependencies {
   testCompile 'org.logl:logl-logl'
   testCompile 'org.logl:logl-vertx'
 
+  testCompile project(':scuttlebutt-rpc')
+
   testRuntime 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/vertx/SecureScuttlebuttVertxClient.java
+++ b/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/vertx/SecureScuttlebuttVertxClient.java
@@ -50,6 +50,8 @@ public final class SecureScuttlebuttVertxClient {
     private SecureScuttlebuttStreamClient client;
     private ClientHandler handler;
 
+    private Bytes messageBuffer = Bytes.EMPTY;
+
     NetSocketClientHandler(
         Logger logger,
         NetSocket socket,
@@ -94,15 +96,37 @@ public final class SecureScuttlebuttVertxClient {
           handshakeCounter++;
         } else {
           Bytes message = client.readFromServer(Bytes.wrapBuffer(buffer));
-          if (message == null) {
-            return;
+          messageBuffer = Bytes.concatenate(messageBuffer, message);
+
+          // Process any whole RPC message repsonses we have, and leave any partial ones at the end in the buffer
+          // We may have 1 or more whole messages, or 1 and a half, etc..
+          while (messageBuffer.size() >= 9) {
+
+            Bytes header = messageBuffer.slice(0, 9);
+            int bodyLength = getBodyLength(header);
+            int headerSize = 9;
+
+            if ((messageBuffer.size() - headerSize) >= (bodyLength)) {
+
+              int headerAndBodyLength = bodyLength + headerSize;
+              Bytes wholeMessage = messageBuffer.slice(0, headerAndBodyLength);
+
+              if (SecureScuttlebuttStreamServer.isGoodbye(wholeMessage)) {
+                logger.debug("Goodbye received from remote peer");
+                socket.close();
+              } else {
+                handler.receivedMessage(wholeMessage);
+              }
+
+              // We've removed 1 RPC message from the message buffer, leave the remaining messages / part of a message
+              // in the buffer to be processed in the next iteration
+              messageBuffer = messageBuffer.slice(headerAndBodyLength);
+            } else {
+              // We don't have a full RPC message, leave the bytes in the buffer for when more arrive
+              break;
+            }
           }
-          if (SecureScuttlebuttStreamServer.isGoodbye(message)) {
-            logger.debug("Goodbye received from remote peer");
-            socket.close();
-          } else {
-            handler.receivedMessage(message);
-          }
+
         }
       } catch (HandshakeException | StreamException e) {
         completionHandle.completeExceptionally(e);
@@ -117,6 +141,12 @@ public final class SecureScuttlebuttVertxClient {
         throw new RuntimeException(t);
       }
     }
+  }
+
+  private int getBodyLength(Bytes rpcHeader) {
+    Bytes size = rpcHeader.slice(1, 4);
+    int bodySize = ((size.get(0) & 0xFF) << 8) + ((size.get(1) & 0xFF) << 8) + ((size.get(2) & 0xFF) << 8) + ((size.get(3) & 0xFF));
+    return bodySize;
   }
 
   private final LoggerProvider loggerProvider;

--- a/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/vertx/SecureScuttlebuttVertxClient.java
+++ b/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/vertx/SecureScuttlebuttVertxClient.java
@@ -145,7 +145,10 @@ public final class SecureScuttlebuttVertxClient {
 
   private int getBodyLength(Bytes rpcHeader) {
     Bytes size = rpcHeader.slice(1, 4);
-    int bodySize = ((size.get(0) & 0xFF) << 8) + ((size.get(1) & 0xFF) << 8) + ((size.get(2) & 0xFF) << 8) + ((size.get(3) & 0xFF));
+    int bodySize = ((size.get(0) & 0xFF) << 8)
+        + ((size.get(1) & 0xFF) << 8)
+        + ((size.get(2) & 0xFF) << 8)
+        + ((size.get(3) & 0xFF));
     return bodySize;
   }
 

--- a/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/vertx/SecureScuttlebuttVertxClient.java
+++ b/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/vertx/SecureScuttlebuttVertxClient.java
@@ -98,13 +98,14 @@ public final class SecureScuttlebuttVertxClient {
           Bytes message = client.readFromServer(Bytes.wrapBuffer(buffer));
           messageBuffer = Bytes.concatenate(messageBuffer, message);
 
+          int headerSize = 9;
+
           // Process any whole RPC message repsonses we have, and leave any partial ones at the end in the buffer
           // We may have 1 or more whole messages, or 1 and a half, etc..
-          while (messageBuffer.size() >= 9) {
+          while (messageBuffer.size() >= headerSize) {
 
             Bytes header = messageBuffer.slice(0, 9);
             int bodyLength = getBodyLength(header);
-            int headerSize = 9;
 
             if ((messageBuffer.size() - headerSize) >= (bodyLength)) {
 
@@ -145,11 +146,7 @@ public final class SecureScuttlebuttVertxClient {
 
   private int getBodyLength(Bytes rpcHeader) {
     Bytes size = rpcHeader.slice(1, 4);
-    int bodySize = ((size.get(0) & 0xFF) << 8)
-        + ((size.get(1) & 0xFF) << 8)
-        + ((size.get(2) & 0xFF) << 8)
-        + ((size.get(3) & 0xFF));
-    return bodySize;
+    return size.toInt();
   }
 
   private final LoggerProvider loggerProvider;

--- a/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/vertx/SecureScuttlebuttVertxServer.java
+++ b/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/vertx/SecureScuttlebuttVertxServer.java
@@ -45,6 +45,8 @@ public final class SecureScuttlebuttVertxServer {
     SecureScuttlebuttHandshakeServer handshakeServer =
         SecureScuttlebuttHandshakeServer.create(keyPair, networkIdentifier);
 
+    private Bytes messageBuffer = Bytes.EMPTY;
+
     void handle(NetSocket netSocket) {
       this.netSocket = netSocket;
       netSocket.closeHandler(res -> {
@@ -79,10 +81,34 @@ public final class SecureScuttlebuttVertxServer {
           });
         } else {
           Bytes message = streamServer.readFromClient(Bytes.wrapBuffer(buffer));
-          if (SecureScuttlebuttStreamServer.isGoodbye(message)) {
-            netSocket.close();
-          } else {
-            handler.receivedMessage(message);
+          messageBuffer = Bytes.concatenate(messageBuffer, message);
+
+          // Process any whole RPC message repsonses we have, and leave any partial ones at the end in the buffer
+          // We may have 1 or more whole messages, or 1 and a half, etc..
+          while (messageBuffer.size() >= 9) {
+
+            Bytes header = messageBuffer.slice(0, 9);
+            int bodyLength = getBodyLength(header);
+            int headerSize = 9;
+
+            if ((messageBuffer.size() - headerSize) >= (bodyLength)) {
+
+              int headerAndBodyLength = bodyLength + headerSize;
+              Bytes wholeMessage = messageBuffer.slice(0, headerAndBodyLength);
+
+              if (SecureScuttlebuttStreamServer.isGoodbye(wholeMessage)) {
+                netSocket.close();
+              } else {
+                handler.receivedMessage(wholeMessage);
+              }
+
+              // We've removed 1 RPC message from the message buffer, leave the remaining messages / part of a message
+              // in the buffer to be processed in the next iteration
+              messageBuffer = messageBuffer.slice(headerAndBodyLength);
+            } else {
+              // We don't have a full RPC message, leave the bytes in the buffer for when more arrive
+              break;
+            }
           }
         }
       } catch (HandshakeException | StreamException e) {
@@ -90,6 +116,15 @@ public final class SecureScuttlebuttVertxServer {
         netSocket.close();
       }
     }
+  }
+
+  private int getBodyLength(Bytes rpcHeader) {
+    Bytes size = rpcHeader.slice(1, 4);
+    int bodySize = ((size.get(0) & 0xFF) << 8)
+        + ((size.get(1) & 0xFF) << 8)
+        + ((size.get(2) & 0xFF) << 8)
+        + ((size.get(3) & 0xFF));
+    return bodySize;
   }
 
   private final Vertx vertx;

--- a/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/vertx/SecureScuttlebuttVertxServer.java
+++ b/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/vertx/SecureScuttlebuttVertxServer.java
@@ -83,13 +83,14 @@ public final class SecureScuttlebuttVertxServer {
           Bytes message = streamServer.readFromClient(Bytes.wrapBuffer(buffer));
           messageBuffer = Bytes.concatenate(messageBuffer, message);
 
+          int headerSize = 9;
+
           // Process any whole RPC message repsonses we have, and leave any partial ones at the end in the buffer
           // We may have 1 or more whole messages, or 1 and a half, etc..
-          while (messageBuffer.size() >= 9) {
+          while (messageBuffer.size() >= headerSize) {
 
             Bytes header = messageBuffer.slice(0, 9);
             int bodyLength = getBodyLength(header);
-            int headerSize = 9;
 
             if ((messageBuffer.size() - headerSize) >= (bodyLength)) {
 
@@ -120,11 +121,7 @@ public final class SecureScuttlebuttVertxServer {
 
   private int getBodyLength(Bytes rpcHeader) {
     Bytes size = rpcHeader.slice(1, 4);
-    int bodySize = ((size.get(0) & 0xFF) << 8)
-        + ((size.get(1) & 0xFF) << 8)
-        + ((size.get(2) & 0xFF) << 8)
-        + ((size.get(3) & 0xFF));
-    return bodySize;
+    return size.toInt();
   }
 
   private final Vertx vertx;

--- a/scuttlebutt-handshake/src/test/java/net/consensys/cava/scuttlebutt/handshake/vertx/VertxIntegrationTest.java
+++ b/scuttlebutt-handshake/src/test/java/net/consensys/cava/scuttlebutt/handshake/vertx/VertxIntegrationTest.java
@@ -22,6 +22,8 @@ import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.crypto.sodium.Signature;
 import net.consensys.cava.junit.VertxExtension;
 import net.consensys.cava.junit.VertxInstance;
+import net.consensys.cava.scuttlebutt.rpc.RPCCodec;
+import net.consensys.cava.scuttlebutt.rpc.RPCFlag;
 
 import java.io.BufferedWriter;
 import java.io.OutputStreamWriter;
@@ -114,10 +116,21 @@ class VertxIntegrationTest {
 
     Thread.sleep(1000);
     assertNotNull(handler);
-    handler.sendMessage(Bytes.fromHexString("deadbeef"));
+
+    String rpcRequestBody = "{\"name\": [\"whoami\"],\"type\": \"async\",\"args\":[]}";
+    Bytes rpcRequest = RPCCodec.encodeRequest(rpcRequestBody, RPCFlag.BodyType.JSON);
+
+    handler.sendMessage(rpcRequest);
+
     Thread.sleep(1000);
     MyServerHandler serverHandler = serverHandlerRef.get();
-    assertEquals(Bytes.fromHexString("deadbeef"), serverHandler.received);
+
+    Bytes receivedBytes = serverHandler.received;
+    Bytes receivedBody = receivedBytes.slice(9);
+
+    Bytes requestBody = rpcRequest.slice(9);
+
+    assertEquals(requestBody, receivedBody);
 
     handler.closeStream();
     Thread.sleep(1000);

--- a/scuttlebutt-rpc/src/test/java/net/consensys/cava/scuttlebutt/rpc/PatchworkIntegrationTest.java
+++ b/scuttlebutt-rpc/src/test/java/net/consensys/cava/scuttlebutt/rpc/PatchworkIntegrationTest.java
@@ -69,8 +69,12 @@ class PatchworkIntegrationTest {
 
     @Override
     public void receivedMessage(Bytes message) {
-      System.out.println("We received a message?");
-      System.out.println(new String(message.toArrayUnsafe(), UTF_8));
+
+      RPCMessage rpcMessage = new RPCMessage(message);
+
+      System.out.println(rpcMessage.asString());
+
+
     }
 
     @Override

--- a/scuttlebutt-rpc/src/test/java/net/consensys/cava/scuttlebutt/rpc/PatchworkIntegrationTest.java
+++ b/scuttlebutt-rpc/src/test/java/net/consensys/cava/scuttlebutt/rpc/PatchworkIntegrationTest.java
@@ -103,7 +103,6 @@ class PatchworkIntegrationTest {
         new PrintWriter(new BufferedWriter(new OutputStreamWriter(System.out, UTF_8))));
     LoglLogDelegateFactory.setProvider(loggerProvider);
 
-
     Optional<String> ssbDir = Optional.fromNullable(System.getenv().get("ssb_dir"));
     Optional<String> homePath =
         Optional.fromNullable(System.getProperty("user.home")).transform(home -> home + "/.ssb");


### PR DESCRIPTION
Sometimes multiple RPC responses arrive to the socket read buffer at once. At present, the implementation of `ClientHandler` and `ServerHandler` would have to inspect the header for the body size, then delimit the individual messages in this fashion - however, the decryption functionality has already done this so we might as well just hand over the individual message byte buffers from it so that the ClientHandler implementation can process one RPC response at a time.

At a high level, these can then be marshalled into the `RPCMessage` class, and then the body into an appropriate Java class / stream of classes. I will play around with this and make a separate pull request for it.