### PR TITLE
Fixes memory leak when decrypting scuttlebutt incoming messages

### DIFF
--- a/crypto/src/main/java/net/consensys/cava/crypto/sodium/SecretBox.java
+++ b/crypto/src/main/java/net/consensys/cava/crypto/sodium/SecretBox.java
@@ -193,7 +193,7 @@ public final class SecretBox {
   /**
    * A SecretBox nonce.
    */
-  public static final class Nonce implements AutoCloseable {
+  public static final class Nonce implements Destroyable {
     final Allocated value;
 
     private Nonce(Pointer ptr, int length) {
@@ -230,6 +230,7 @@ public final class SecretBox {
       return Sodium.dup(bytes, Nonce::new);
     }
 
+    @Override
     public void destroy() {
       this.value.destroy();
     }
@@ -315,11 +316,6 @@ public final class SecretBox {
      */
     public byte[] bytesArray() {
       return value.bytesArray();
-    }
-
-    @Override
-    public void close() {
-      destroy();
     }
   }
 

--- a/crypto/src/main/java/net/consensys/cava/crypto/sodium/SecretBox.java
+++ b/crypto/src/main/java/net/consensys/cava/crypto/sodium/SecretBox.java
@@ -193,7 +193,7 @@ public final class SecretBox {
   /**
    * A SecretBox nonce.
    */
-  public static final class Nonce {
+  public static final class Nonce implements AutoCloseable {
     final Allocated value;
 
     private Nonce(Pointer ptr, int length) {
@@ -228,6 +228,10 @@ public final class SecretBox {
             "nonce must be " + Sodium.crypto_secretbox_noncebytes() + " bytes, got " + bytes.length);
       }
       return Sodium.dup(bytes, Nonce::new);
+    }
+
+    public void destroy() {
+      this.value.destroy();
     }
 
     /**
@@ -311,6 +315,11 @@ public final class SecretBox {
      */
     public byte[] bytesArray() {
       return value.bytesArray();
+    }
+
+    @Override
+    public void close() throws Exception {
+      destroy();
     }
   }
 

--- a/crypto/src/main/java/net/consensys/cava/crypto/sodium/SecretBox.java
+++ b/crypto/src/main/java/net/consensys/cava/crypto/sodium/SecretBox.java
@@ -318,7 +318,7 @@ public final class SecretBox {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
       destroy();
     }
   }

--- a/crypto/src/main/java/net/consensys/cava/crypto/sodium/Sodium.java
+++ b/crypto/src/main/java/net/consensys/cava/crypto/sodium/Sodium.java
@@ -271,7 +271,6 @@ public final class Sodium {
 
   static <T> T dup(byte[] bytes, BiFunction<Pointer, Integer, T> ctr) {
     Pointer ptr = Sodium.dup(bytes);
-
     try {
       return ctr.apply(ptr, bytes.length);
     } catch (Throwable e) {

--- a/crypto/src/main/java/net/consensys/cava/crypto/sodium/Sodium.java
+++ b/crypto/src/main/java/net/consensys/cava/crypto/sodium/Sodium.java
@@ -271,6 +271,7 @@ public final class Sodium {
 
   static <T> T dup(byte[] bytes, BiFunction<Pointer, Integer, T> ctr) {
     Pointer ptr = Sodium.dup(bytes);
+
     try {
       return ctr.apply(ptr, bytes.length);
     } catch (Throwable e) {

--- a/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/SecureScuttlebuttStream.java
+++ b/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/SecureScuttlebuttStream.java
@@ -22,142 +22,140 @@ import java.util.List;
 
 final class SecureScuttlebuttStream implements SecureScuttlebuttStreamClient, SecureScuttlebuttStreamServer {
 
-    private final SecretBox.Key clientToServerKey;
-    private final MutableBytes clientToServerNonce;
-    private final SecretBox.Key serverToClientKey;
-    private final MutableBytes serverToClientNonce;
+  private final SecretBox.Key clientToServerKey;
+  private final MutableBytes clientToServerNonce;
+  private final SecretBox.Key serverToClientKey;
+  private final MutableBytes serverToClientNonce;
 
-    SecureScuttlebuttStream(
-            SHA256Hash.Hash clientToServerKey,
-            Bytes clientToServerNonce,
-            SHA256Hash.Hash serverToClientKey,
-            Bytes serverToClientNonce) {
-        this.clientToServerKey = SecretBox.Key.fromHash(clientToServerKey);
-        this.serverToClientKey = SecretBox.Key.fromHash(serverToClientKey);
-        this.clientToServerNonce = clientToServerNonce.mutableCopy();
-        this.serverToClientNonce = serverToClientNonce.mutableCopy();
+  SecureScuttlebuttStream(
+      SHA256Hash.Hash clientToServerKey,
+      Bytes clientToServerNonce,
+      SHA256Hash.Hash serverToClientKey,
+      Bytes serverToClientNonce) {
+    this.clientToServerKey = SecretBox.Key.fromHash(clientToServerKey);
+    this.serverToClientKey = SecretBox.Key.fromHash(serverToClientKey);
+    this.clientToServerNonce = clientToServerNonce.mutableCopy();
+    this.serverToClientNonce = serverToClientNonce.mutableCopy();
+  }
+
+  @Override
+  public synchronized Bytes sendToServer(Bytes message) {
+    return encrypt(message, clientToServerKey, clientToServerNonce);
+  }
+
+  @Override
+  public synchronized Bytes sendGoodbyeToServer() {
+    return sendToServer(Bytes.wrap(new byte[18]));
+  }
+
+  @Override
+  public synchronized Bytes readFromServer(Bytes message) {
+    return decrypt(message, serverToClientKey, serverToClientNonce, false);
+  }
+
+  @Override
+  public synchronized Bytes sendToClient(Bytes message) {
+    return encrypt(message, serverToClientKey, serverToClientNonce);
+  }
+
+  @Override
+  public synchronized Bytes sendGoodbyeToClient() {
+    return sendToClient(Bytes.wrap(new byte[18]));
+  }
+
+  @Override
+  public synchronized Bytes readFromClient(Bytes message) {
+    return decrypt(message, clientToServerKey, clientToServerNonce, true);
+  }
+
+  private Bytes clientToServerBuffer = Bytes.EMPTY;
+  private Bytes serverToClientBuffer = Bytes.EMPTY;
+
+  private Bytes decrypt(Bytes message, SecretBox.Key key, MutableBytes nonce, boolean isClientToServer) {
+    int index = 0;
+    List<Bytes> decryptedMessages = new ArrayList<>();
+    Bytes messageWithBuffer;
+    if (isClientToServer) {
+      messageWithBuffer = Bytes.concatenate(clientToServerBuffer, message);
+    } else {
+      messageWithBuffer = Bytes.concatenate(serverToClientBuffer, message);
     }
 
-    @Override
-    public synchronized Bytes sendToServer(Bytes message) {
-        return encrypt(message, clientToServerKey, clientToServerNonce);
+    while (index < messageWithBuffer.size()) {
+      Bytes decryptedMessage = decryptMessage(messageWithBuffer.slice(index), key, nonce);
+      if (decryptedMessage == null) {
+        break;
+      }
+      decryptedMessages.add(decryptedMessage);
+      index += decryptedMessage.size() + 34;
     }
 
-    @Override
-    public synchronized Bytes sendGoodbyeToServer() {
-        return sendToServer(Bytes.wrap(new byte[18]));
+    if (isClientToServer) {
+      clientToServerBuffer = messageWithBuffer.slice(index);
+    } else {
+      serverToClientBuffer = messageWithBuffer.slice(index);
     }
 
-    @Override
-    public synchronized Bytes readFromServer(Bytes message) {
-        return decrypt(message, serverToClientKey, serverToClientNonce, false);
-    }
+    return Bytes.concatenate(decryptedMessages.toArray(new Bytes[0]));
+  }
 
-    @Override
-    public synchronized Bytes sendToClient(Bytes message) {
-        return encrypt(message, serverToClientKey, serverToClientNonce);
-    }
+  private Bytes decryptMessage(Bytes message, SecretBox.Key key, MutableBytes nonce) {
+    MutableBytes snapshotNonce = nonce.mutableCopy();
 
-    @Override
-    public synchronized Bytes sendGoodbyeToClient() {
-        return sendToClient(Bytes.wrap(new byte[18]));
-    }
-
-    @Override
-    public synchronized Bytes readFromClient(Bytes message) {
-        return decrypt(message, clientToServerKey, clientToServerNonce, true);
-    }
-
-    private Bytes clientToServerBuffer = Bytes.EMPTY;
-    private Bytes serverToClientBuffer = Bytes.EMPTY;
-
-    private Bytes decrypt(Bytes message, SecretBox.Key key, MutableBytes nonce, boolean isClientToServer) {
-        int index = 0;
-        List<Bytes> decryptedMessages = new ArrayList<>();
-        Bytes messageWithBuffer;
-        if (isClientToServer) {
-            messageWithBuffer = Bytes.concatenate(clientToServerBuffer, message);
-        } else {
-            messageWithBuffer = Bytes.concatenate(serverToClientBuffer, message);
+    try {
+      try (SecretBox.Nonce headerNonce = SecretBox.Nonce.fromBytes(snapshotNonce);
+          SecretBox.Nonce bodyNonce = SecretBox.Nonce.fromBytes(snapshotNonce.increment());) {
+        if (message.size() < 34) {
+          return null;
         }
 
-        while (index < messageWithBuffer.size()) {
-            Bytes decryptedMessage = decryptMessage(messageWithBuffer.slice(index), key, nonce);
-            if (decryptedMessage == null) {
-                break;
-            }
-            decryptedMessages.add(decryptedMessage);
-            index += decryptedMessage.size() + 34;
+        Bytes decryptedHeader = SecretBox.decrypt(message.slice(0, 34), key, headerNonce);
+
+        if (decryptedHeader == null) {
+          throw new StreamException("Failed to decrypt message header");
         }
 
-        if (isClientToServer) {
-            clientToServerBuffer = messageWithBuffer.slice(index);
-        } else {
-            serverToClientBuffer = messageWithBuffer.slice(index);
+        int bodySize = ((decryptedHeader.get(0) & 0xFF) << 8) + (decryptedHeader.get(1) & 0xFF);
+        if (message.size() < bodySize + 34) {
+          return null;
         }
-
-        return Bytes.concatenate(decryptedMessages.toArray(new Bytes[0]));
-    }
-
-    private Bytes decryptMessage(Bytes message, SecretBox.Key key, MutableBytes nonce) {
-        MutableBytes snapshotNonce = nonce.mutableCopy();
-
-        try {
-            try (
-                    SecretBox.Nonce headerNonce = SecretBox.Nonce.fromBytes(snapshotNonce);
-                    SecretBox.Nonce bodyNonce = SecretBox.Nonce.fromBytes(snapshotNonce.increment());
-            ) {
-                if (message.size() < 34) {
-                    return null;
-                }
-
-                Bytes decryptedHeader = SecretBox.decrypt(message.slice(0, 34), key, headerNonce);
-
-                if (decryptedHeader == null) {
-                    throw new StreamException("Failed to decrypt message header");
-                }
-
-                int bodySize = ((decryptedHeader.get(0) & 0xFF) << 8) + (decryptedHeader.get(1) & 0xFF);
-                if (message.size() < bodySize + 34) {
-                    return null;
-                }
-                Bytes body = message.slice(34, bodySize);
-                Bytes decryptedBody = SecretBox.decrypt(Bytes.concatenate(decryptedHeader.slice(2), body), key, bodyNonce);
-                if (decryptedBody == null) {
-                    throw new StreamException("Failed to decrypt message");
-                }
-                nonce.increment().increment();
-
-                return decryptedBody;
-
-            }
-        } catch (Exception e) {
-            throw new StreamException(e.getMessage());
+        Bytes body = message.slice(34, bodySize);
+        Bytes decryptedBody = SecretBox.decrypt(Bytes.concatenate(decryptedHeader.slice(2), body), key, bodyNonce);
+        if (decryptedBody == null) {
+          throw new StreamException("Failed to decrypt message");
         }
-    }
+        nonce.increment().increment();
 
-    private Bytes encrypt(Bytes message, SecretBox.Key clientToServerKey, MutableBytes clientToServerNonce) {
-        int messages = (int) Math.ceil((double) message.size() / 4096d);
-        Bytes[] encryptedMessages = new Bytes[messages];
-        for (int i = 0; i < messages; i++) {
-            Bytes encryptedMessage = encryptMessage(
-                    message.slice(i * 4096, Math.min((i + 1) * 4096, message.size() - i * 4096)),
-                    clientToServerKey,
-                    clientToServerNonce);
-            encryptedMessages[i] = encryptedMessage;
-        }
-        return Bytes.concatenate(encryptedMessages);
-    }
+        return decryptedBody;
 
-    private Bytes encryptMessage(Bytes message, SecretBox.Key key, MutableBytes nonce) {
-        SecretBox.Nonce headerNonce = SecretBox.Nonce.fromBytes(nonce);
-        SecretBox.Nonce bodyNonce = SecretBox.Nonce.fromBytes(nonce.increment());
-        nonce.increment();
-        Bytes encryptedBody = SecretBox.encrypt(message, key, bodyNonce);
-        int bodySize = encryptedBody.size() - 16;
-        Bytes encodedBodySize = Bytes.ofUnsignedInt(bodySize).slice(2);
-        Bytes header = SecretBox.encrypt(Bytes.concatenate(encodedBodySize, encryptedBody.slice(0, 16)), key, headerNonce);
-
-        return Bytes.concatenate(header, encryptedBody.slice(16));
+      }
+    } catch (Exception e) {
+      throw new StreamException(e.getMessage());
     }
+  }
+
+  private Bytes encrypt(Bytes message, SecretBox.Key clientToServerKey, MutableBytes clientToServerNonce) {
+    int messages = (int) Math.ceil((double) message.size() / 4096d);
+    Bytes[] encryptedMessages = new Bytes[messages];
+    for (int i = 0; i < messages; i++) {
+      Bytes encryptedMessage = encryptMessage(
+          message.slice(i * 4096, Math.min((i + 1) * 4096, message.size() - i * 4096)),
+          clientToServerKey,
+          clientToServerNonce);
+      encryptedMessages[i] = encryptedMessage;
+    }
+    return Bytes.concatenate(encryptedMessages);
+  }
+
+  private Bytes encryptMessage(Bytes message, SecretBox.Key key, MutableBytes nonce) {
+    SecretBox.Nonce headerNonce = SecretBox.Nonce.fromBytes(nonce);
+    SecretBox.Nonce bodyNonce = SecretBox.Nonce.fromBytes(nonce.increment());
+    nonce.increment();
+    Bytes encryptedBody = SecretBox.encrypt(message, key, bodyNonce);
+    int bodySize = encryptedBody.size() - 16;
+    Bytes encodedBodySize = Bytes.ofUnsignedInt(bodySize).slice(2);
+    Bytes header = SecretBox.encrypt(Bytes.concatenate(encodedBodySize, encryptedBody.slice(0, 16)), key, headerNonce);
+
+    return Bytes.concatenate(header, encryptedBody.slice(16));
+  }
 }

--- a/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/SecureScuttlebuttStream.java
+++ b/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/SecureScuttlebuttStream.java
@@ -22,131 +22,142 @@ import java.util.List;
 
 final class SecureScuttlebuttStream implements SecureScuttlebuttStreamClient, SecureScuttlebuttStreamServer {
 
-  private final SecretBox.Key clientToServerKey;
-  private final MutableBytes clientToServerNonce;
-  private final SecretBox.Key serverToClientKey;
-  private final MutableBytes serverToClientNonce;
+    private final SecretBox.Key clientToServerKey;
+    private final MutableBytes clientToServerNonce;
+    private final SecretBox.Key serverToClientKey;
+    private final MutableBytes serverToClientNonce;
 
-  SecureScuttlebuttStream(
-      SHA256Hash.Hash clientToServerKey,
-      Bytes clientToServerNonce,
-      SHA256Hash.Hash serverToClientKey,
-      Bytes serverToClientNonce) {
-    this.clientToServerKey = SecretBox.Key.fromHash(clientToServerKey);
-    this.serverToClientKey = SecretBox.Key.fromHash(serverToClientKey);
-    this.clientToServerNonce = clientToServerNonce.mutableCopy();
-    this.serverToClientNonce = serverToClientNonce.mutableCopy();
-  }
-
-  @Override
-  public synchronized Bytes sendToServer(Bytes message) {
-    return encrypt(message, clientToServerKey, clientToServerNonce);
-  }
-
-  @Override
-  public synchronized Bytes sendGoodbyeToServer() {
-    return sendToServer(Bytes.wrap(new byte[18]));
-  }
-
-  @Override
-  public synchronized Bytes readFromServer(Bytes message) {
-    return decrypt(message, serverToClientKey, serverToClientNonce, false);
-  }
-
-  @Override
-  public synchronized Bytes sendToClient(Bytes message) {
-    return encrypt(message, serverToClientKey, serverToClientNonce);
-  }
-
-  @Override
-  public synchronized Bytes sendGoodbyeToClient() {
-    return sendToClient(Bytes.wrap(new byte[18]));
-  }
-
-  @Override
-  public synchronized Bytes readFromClient(Bytes message) {
-    return decrypt(message, clientToServerKey, clientToServerNonce, true);
-  }
-
-  private Bytes clientToServerBuffer = Bytes.EMPTY;
-  private Bytes serverToClientBuffer = Bytes.EMPTY;
-
-  private Bytes decrypt(Bytes message, SecretBox.Key key, MutableBytes nonce, boolean isClientToServer) {
-    int index = 0;
-    List<Bytes> decryptedMessages = new ArrayList<>();
-    Bytes messageWithBuffer;
-    if (isClientToServer) {
-      messageWithBuffer = Bytes.concatenate(clientToServerBuffer, message);
-    } else {
-      messageWithBuffer = Bytes.concatenate(serverToClientBuffer, message);
+    SecureScuttlebuttStream(
+            SHA256Hash.Hash clientToServerKey,
+            Bytes clientToServerNonce,
+            SHA256Hash.Hash serverToClientKey,
+            Bytes serverToClientNonce) {
+        this.clientToServerKey = SecretBox.Key.fromHash(clientToServerKey);
+        this.serverToClientKey = SecretBox.Key.fromHash(serverToClientKey);
+        this.clientToServerNonce = clientToServerNonce.mutableCopy();
+        this.serverToClientNonce = serverToClientNonce.mutableCopy();
     }
 
-    while (index < messageWithBuffer.size()) {
-      Bytes decryptedMessage = decryptMessage(messageWithBuffer.slice(index), key, nonce);
-      if (decryptedMessage == null) {
-        break;
-      }
-      decryptedMessages.add(decryptedMessage);
-      index += decryptedMessage.size() + 34;
+    @Override
+    public synchronized Bytes sendToServer(Bytes message) {
+        return encrypt(message, clientToServerKey, clientToServerNonce);
     }
 
-    if (isClientToServer) {
-      clientToServerBuffer = messageWithBuffer.slice(index);
-    } else {
-      serverToClientBuffer = messageWithBuffer.slice(index);
+    @Override
+    public synchronized Bytes sendGoodbyeToServer() {
+        return sendToServer(Bytes.wrap(new byte[18]));
     }
 
-    return Bytes.concatenate(decryptedMessages.toArray(new Bytes[0]));
-  }
-
-  private Bytes decryptMessage(Bytes message, SecretBox.Key key, MutableBytes nonce) {
-    if (message.size() < 34) {
-      return null;
-    }
-    MutableBytes snapshotNonce = nonce.mutableCopy();
-    SecretBox.Nonce headerNonce = SecretBox.Nonce.fromBytes(snapshotNonce);
-    SecretBox.Nonce bodyNonce = SecretBox.Nonce.fromBytes(snapshotNonce.increment());
-    Bytes decryptedHeader = SecretBox.decrypt(message.slice(0, 34), key, headerNonce);
-
-    if (decryptedHeader == null) {
-      throw new StreamException("Failed to decrypt message header");
+    @Override
+    public synchronized Bytes readFromServer(Bytes message) {
+        return decrypt(message, serverToClientKey, serverToClientNonce, false);
     }
 
-    int bodySize = ((decryptedHeader.get(0) & 0xFF) << 8) + (decryptedHeader.get(1) & 0xFF);
-    if (message.size() < bodySize + 34) {
-      return null;
+    @Override
+    public synchronized Bytes sendToClient(Bytes message) {
+        return encrypt(message, serverToClientKey, serverToClientNonce);
     }
-    Bytes body = message.slice(34, bodySize);
-    Bytes decryptedBody = SecretBox.decrypt(Bytes.concatenate(decryptedHeader.slice(2), body), key, bodyNonce);
-    if (decryptedBody == null) {
-      throw new StreamException("Failed to decrypt message");
+
+    @Override
+    public synchronized Bytes sendGoodbyeToClient() {
+        return sendToClient(Bytes.wrap(new byte[18]));
     }
-    nonce.increment().increment();
-    return decryptedBody;
-  }
 
-  private Bytes encrypt(Bytes message, SecretBox.Key clientToServerKey, MutableBytes clientToServerNonce) {
-    int messages = (int) Math.ceil((double) message.size() / 4096d);
-    Bytes[] encryptedMessages = new Bytes[messages];
-    for (int i = 0; i < messages; i++) {
-      Bytes encryptedMessage = encryptMessage(
-          message.slice(i * 4096, Math.min((i + 1) * 4096, message.size() - i * 4096)),
-          clientToServerKey,
-          clientToServerNonce);
-      encryptedMessages[i] = encryptedMessage;
+    @Override
+    public synchronized Bytes readFromClient(Bytes message) {
+        return decrypt(message, clientToServerKey, clientToServerNonce, true);
     }
-    return Bytes.concatenate(encryptedMessages);
-  }
 
-  private Bytes encryptMessage(Bytes message, SecretBox.Key key, MutableBytes nonce) {
-    SecretBox.Nonce headerNonce = SecretBox.Nonce.fromBytes(nonce);
-    SecretBox.Nonce bodyNonce = SecretBox.Nonce.fromBytes(nonce.increment());
-    nonce.increment();
-    Bytes encryptedBody = SecretBox.encrypt(message, key, bodyNonce);
-    int bodySize = encryptedBody.size() - 16;
-    Bytes encodedBodySize = Bytes.ofUnsignedInt(bodySize).slice(2);
-    Bytes header = SecretBox.encrypt(Bytes.concatenate(encodedBodySize, encryptedBody.slice(0, 16)), key, headerNonce);
+    private Bytes clientToServerBuffer = Bytes.EMPTY;
+    private Bytes serverToClientBuffer = Bytes.EMPTY;
 
-    return Bytes.concatenate(header, encryptedBody.slice(16));
-  }
+    private Bytes decrypt(Bytes message, SecretBox.Key key, MutableBytes nonce, boolean isClientToServer) {
+        int index = 0;
+        List<Bytes> decryptedMessages = new ArrayList<>();
+        Bytes messageWithBuffer;
+        if (isClientToServer) {
+            messageWithBuffer = Bytes.concatenate(clientToServerBuffer, message);
+        } else {
+            messageWithBuffer = Bytes.concatenate(serverToClientBuffer, message);
+        }
+
+        while (index < messageWithBuffer.size()) {
+            Bytes decryptedMessage = decryptMessage(messageWithBuffer.slice(index), key, nonce);
+            if (decryptedMessage == null) {
+                break;
+            }
+            decryptedMessages.add(decryptedMessage);
+            index += decryptedMessage.size() + 34;
+        }
+
+        if (isClientToServer) {
+            clientToServerBuffer = messageWithBuffer.slice(index);
+        } else {
+            serverToClientBuffer = messageWithBuffer.slice(index);
+        }
+
+        return Bytes.concatenate(decryptedMessages.toArray(new Bytes[0]));
+    }
+
+    private Bytes decryptMessage(Bytes message, SecretBox.Key key, MutableBytes nonce) {
+        MutableBytes snapshotNonce = nonce.mutableCopy();
+
+        try {
+            try (
+                    SecretBox.Nonce headerNonce = SecretBox.Nonce.fromBytes(snapshotNonce);
+                    SecretBox.Nonce bodyNonce = SecretBox.Nonce.fromBytes(snapshotNonce.increment());
+            ) {
+                if (message.size() < 34) {
+                    return null;
+                }
+
+                Bytes decryptedHeader = SecretBox.decrypt(message.slice(0, 34), key, headerNonce);
+
+                if (decryptedHeader == null) {
+                    throw new StreamException("Failed to decrypt message header");
+                }
+
+                int bodySize = ((decryptedHeader.get(0) & 0xFF) << 8) + (decryptedHeader.get(1) & 0xFF);
+                if (message.size() < bodySize + 34) {
+                    return null;
+                }
+                Bytes body = message.slice(34, bodySize);
+                Bytes decryptedBody = SecretBox.decrypt(Bytes.concatenate(decryptedHeader.slice(2), body), key, bodyNonce);
+                if (decryptedBody == null) {
+                    throw new StreamException("Failed to decrypt message");
+                }
+                nonce.increment().increment();
+
+                return decryptedBody;
+
+            }
+        } catch (Exception e) {
+            throw new StreamException(e.getMessage());
+        }
+    }
+
+    private Bytes encrypt(Bytes message, SecretBox.Key clientToServerKey, MutableBytes clientToServerNonce) {
+        int messages = (int) Math.ceil((double) message.size() / 4096d);
+        Bytes[] encryptedMessages = new Bytes[messages];
+        for (int i = 0; i < messages; i++) {
+            Bytes encryptedMessage = encryptMessage(
+                    message.slice(i * 4096, Math.min((i + 1) * 4096, message.size() - i * 4096)),
+                    clientToServerKey,
+                    clientToServerNonce);
+            encryptedMessages[i] = encryptedMessage;
+        }
+        return Bytes.concatenate(encryptedMessages);
+    }
+
+    private Bytes encryptMessage(Bytes message, SecretBox.Key key, MutableBytes nonce) {
+        SecretBox.Nonce headerNonce = SecretBox.Nonce.fromBytes(nonce);
+        SecretBox.Nonce bodyNonce = SecretBox.Nonce.fromBytes(nonce.increment());
+        nonce.increment();
+        Bytes encryptedBody = SecretBox.encrypt(message, key, bodyNonce);
+        int bodySize = encryptedBody.size() - 16;
+        Bytes encodedBodySize = Bytes.ofUnsignedInt(bodySize).slice(2);
+        Bytes header = SecretBox.encrypt(Bytes.concatenate(encodedBodySize, encryptedBody.slice(0, 16)), key, headerNonce);
+
+        return Bytes.concatenate(header, encryptedBody.slice(16));
+    }
 }

--- a/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/SecureScuttlebuttStream.java
+++ b/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/SecureScuttlebuttStream.java
@@ -16,6 +16,7 @@ import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.MutableBytes;
 import net.consensys.cava.crypto.sodium.SHA256Hash;
 import net.consensys.cava.crypto.sodium.SecretBox;
+import net.consensys.cava.crypto.sodium.SodiumException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -129,8 +130,8 @@ final class SecureScuttlebuttStream implements SecureScuttlebuttStreamClient, Se
         return decryptedBody;
 
       }
-    } catch (Exception e) {
-      throw new StreamException(e.getMessage());
+    } catch (SodiumException | OutOfMemoryError ex) {
+      throw new StreamException(ex);
     }
   }
 

--- a/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/StreamException.java
+++ b/scuttlebutt-handshake/src/main/java/net/consensys/cava/scuttlebutt/handshake/StreamException.java
@@ -17,4 +17,9 @@ public final class StreamException extends RuntimeException {
   StreamException(String message) {
     super(message);
   }
+
+  StreamException(Throwable ex) {
+    super(ex);
+  }
+
 }


### PR DESCRIPTION
I believe this changes fixes #205 .

I think this was happening because the underlying JNI `Pointer` for the `header` and `body` nonces weren't being freed until the garbage collector destroyed the objects which no longer had any references. Until the garbage collector destroyed them, the lib sodium `malloc` would periodically fail because there wasn't enough memory available to malloc - but once the garbage collector called `destroy` on the objects memory became free to allocate again, and the decryption would start succeeding again.

Note: this is just a theory from reading the code (i'm not sure how I'd test it empirically) but the changes appear to stop the error happening.

This change also means that if the decryption fails due to a lib sodium error, a `StreamException` will be thrown and the underlying socket (scuttlebutt connection) will be closed.