### PR TITLE
Fix thread deadlock issue in RPC handler.

### DIFF
--- a/scuttlebutt-rpc/build.gradle
+++ b/scuttlebutt-rpc/build.gradle
@@ -4,6 +4,7 @@ dependencies {
   compile project(':bytes')
   compile project(':concurrent')
   compile project(':crypto')
+  compileOnly 'io.vertx:vertx-core'
   compile project(':scuttlebutt')
   compile project(':scuttlebutt-handshake')
   compile 'org.logl:logl-api'

--- a/scuttlebutt-rpc/src/main/java/net/consensys/cava/scuttlebutt/rpc/RPCMessage.java
+++ b/scuttlebutt-rpc/src/main/java/net/consensys/cava/scuttlebutt/rpc/RPCMessage.java
@@ -118,7 +118,7 @@ public final class RPCMessage {
   /**
    *
    * @param objectMapper the objectmatter to deserialize the error with.
-   *                     
+   *
    * @return an exception if this represents an error RPC response, otherwise nothing
    */
   public Optional<RPCRequestFailedException> getException(ObjectMapper objectMapper) {

--- a/scuttlebutt-rpc/src/main/java/net/consensys/cava/scuttlebutt/rpc/RPCMessage.java
+++ b/scuttlebutt-rpc/src/main/java/net/consensys/cava/scuttlebutt/rpc/RPCMessage.java
@@ -15,11 +15,12 @@ package net.consensys.cava.scuttlebutt.rpc;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.scuttlebutt.rpc.mux.exceptions.RPCRequestFailedException;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Optional;
 
 /**
  * Decoded RPC message, making elements of the message available directly.
@@ -104,13 +105,37 @@ public final class RPCMessage {
 
     if (!isErrorMessage()) {
       // If the body of the response is 'true' or the error flag isn't set, it's a successful end condition
-      return Optional.absent();
+      return Optional.empty();
     } else {
       try {
         return Optional.of(asJSON(objectMapper, RPCErrorBody.class));
       } catch (IOException e) {
-        return Optional.absent();
+        return Optional.empty();
       }
+    }
+  }
+
+  /**
+   *
+   * @param objectMapper the objectmatter to deserialize the error with.
+   *                     
+   * @return an exception if this represents an error RPC response, otherwise nothing
+   */
+  public Optional<RPCRequestFailedException> getException(ObjectMapper objectMapper) {
+    if (isErrorMessage()) {
+      Optional<RPCRequestFailedException> exception =
+          getErrorBody(objectMapper).map(errorBody -> new RPCRequestFailedException(errorBody.getMessage()));
+
+      if (!exception.isPresent()) {
+        // If we failed to deserialize into the RPCErrorBody type there may be a bug in the server implementation
+        // which prevented it returning the correct type, so we just print whatever it returned
+        return Optional.of(new RPCRequestFailedException(this.asString()));
+      } else {
+        return exception;
+      }
+
+    } else {
+      return Optional.empty();
     }
   }
 

--- a/scuttlebutt-rpc/src/main/java/net/consensys/cava/scuttlebutt/rpc/RPCResponse.java
+++ b/scuttlebutt-rpc/src/main/java/net/consensys/cava/scuttlebutt/rpc/RPCResponse.java
@@ -41,11 +41,17 @@ public class RPCResponse {
     this.bodyType = bodyType;
   }
 
-  public Bytes getBody() {
+  /**
+   * @return the RPC response body
+   */
+  public Bytes body() {
     return body;
   }
 
-  public BodyType getBodyType() {
+  /**
+   * @return The type of the data contained in the body.
+   */
+  public BodyType bodyType() {
     return bodyType;
   }
 
@@ -55,7 +61,7 @@ public class RPCResponse {
    * @return the body of the message as a UTF-8 string
    */
   public String asString() {
-    return new String(getBody().toArrayUnsafe(), UTF_8);
+    return new String(body().toArrayUnsafe(), UTF_8);
   }
 
   /**
@@ -68,7 +74,7 @@ public class RPCResponse {
    * @throws IOException if an error occurs during marshalling
    */
   public <T> T asJSON(ObjectMapper objectMapper, Class<T> clazz) throws IOException {
-    return objectMapper.readerFor(clazz).readValue(getBody().toArrayUnsafe());
+    return objectMapper.readerFor(clazz).readValue(body().toArrayUnsafe());
   }
 
 }

--- a/scuttlebutt-rpc/src/main/java/net/consensys/cava/scuttlebutt/rpc/RPCResponse.java
+++ b/scuttlebutt-rpc/src/main/java/net/consensys/cava/scuttlebutt/rpc/RPCResponse.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.cava.scuttlebutt.rpc;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.scuttlebutt.rpc.RPCFlag.BodyType;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * A successful RPC response.
+ */
+public class RPCResponse {
+
+  private final Bytes body;
+  private final BodyType bodyType;
+
+  /**
+   * A successful RPC response.
+   *
+   * @param body the body of the response in bytes
+   * @param bodyType the type of the response (e.g. JSON, UTF-8 or binary.)
+   */
+  public RPCResponse(Bytes body, BodyType bodyType) {
+
+    this.body = body;
+    this.bodyType = bodyType;
+  }
+
+  public Bytes getBody() {
+    return body;
+  }
+
+  public BodyType getBodyType() {
+    return bodyType;
+  }
+
+  /**
+   * Provides the body of the message as a UTF-8 string.
+   *
+   * @return the body of the message as a UTF-8 string
+   */
+  public String asString() {
+    return new String(getBody().toArrayUnsafe(), UTF_8);
+  }
+
+  /**
+   * Provides the body of the message, marshalled as a JSON object.
+   *
+   * @param objectMapper the object mapper to deserialize with
+   * @param clazz the JSON object class
+   * @param <T> the matching JSON object class
+   * @return a new instance of the JSON object class
+   * @throws IOException if an error occurs during marshalling
+   */
+  public <T> T asJSON(ObjectMapper objectMapper, Class<T> clazz) throws IOException {
+    return objectMapper.readerFor(clazz).readValue(getBody().toArrayUnsafe());
+  }
+
+}

--- a/scuttlebutt-rpc/src/main/java/net/consensys/cava/scuttlebutt/rpc/mux/Multiplexer.java
+++ b/scuttlebutt-rpc/src/main/java/net/consensys/cava/scuttlebutt/rpc/mux/Multiplexer.java
@@ -14,7 +14,7 @@ package net.consensys.cava.scuttlebutt.rpc.mux;
 
 import net.consensys.cava.concurrent.AsyncResult;
 import net.consensys.cava.scuttlebutt.rpc.RPCAsyncRequest;
-import net.consensys.cava.scuttlebutt.rpc.RPCMessage;
+import net.consensys.cava.scuttlebutt.rpc.RPCResponse;
 import net.consensys.cava.scuttlebutt.rpc.RPCStreamRequest;
 import net.consensys.cava.scuttlebutt.rpc.mux.exceptions.ConnectionClosedException;
 
@@ -35,7 +35,7 @@ public interface Multiplexer {
    *
    * @return an async result which will be completed with the result or an error if the request fails.
    */
-  AsyncResult<RPCMessage> makeAsyncRequest(RPCAsyncRequest request) throws JsonProcessingException;
+  AsyncResult<RPCResponse> makeAsyncRequest(RPCAsyncRequest request) throws JsonProcessingException;
 
   /**
    * Creates a request which opens a stream (e.g. a 'source' in the protocol docs.)

--- a/scuttlebutt-rpc/src/main/java/net/consensys/cava/scuttlebutt/rpc/mux/Multiplexer.java
+++ b/scuttlebutt-rpc/src/main/java/net/consensys/cava/scuttlebutt/rpc/mux/Multiplexer.java
@@ -35,7 +35,7 @@ public interface Multiplexer {
    *
    * @return an async result which will be completed with the result or an error if the request fails.
    */
-  AsyncResult<RPCMessage> makeAsyncRequest(RPCAsyncRequest request);
+  AsyncResult<RPCMessage> makeAsyncRequest(RPCAsyncRequest request) throws JsonProcessingException;
 
   /**
    * Creates a request which opens a stream (e.g. a 'source' in the protocol docs.)

--- a/scuttlebutt-rpc/src/main/java/net/consensys/cava/scuttlebutt/rpc/mux/exceptions/RPCRequestFailedException.java
+++ b/scuttlebutt-rpc/src/main/java/net/consensys/cava/scuttlebutt/rpc/mux/exceptions/RPCRequestFailedException.java
@@ -12,7 +12,7 @@
  */
 package net.consensys.cava.scuttlebutt.rpc.mux.exceptions;
 
-public class RPCRequestFailedException extends Exception {
+public final class RPCRequestFailedException extends RuntimeException {
 
   public RPCRequestFailedException(String errorMessage) {
     super(errorMessage);

--- a/scuttlebutt-rpc/src/main/java/net/consensys/cava/scuttlebutt/rpc/mux/exceptions/RPCRequestFailedException.java
+++ b/scuttlebutt-rpc/src/main/java/net/consensys/cava/scuttlebutt/rpc/mux/exceptions/RPCRequestFailedException.java
@@ -10,32 +10,11 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package net.consensys.cava.scuttlebutt.rpc.mux;
+package net.consensys.cava.scuttlebutt.rpc.mux.exceptions;
 
-import net.consensys.cava.scuttlebutt.rpc.RPCResponse;
+public class RPCRequestFailedException extends Exception {
 
-/**
- * Handles incoming items from a result stream
- */
-public interface ScuttlebuttStreamHandler {
-
-  /**
-   * Handles a new message from the result stream.
-   *
-   * @param message
-   */
-  void onMessage(RPCResponse message);
-
-  /**
-   * Invoked when the stream has been closed.
-   */
-  void onStreamEnd();
-
-  /**
-   * Invoked when there is an error in the stream.
-   *
-   * @param ex the underlying error
-   */
-  void onStreamError(Exception ex);
-
+  public RPCRequestFailedException(String errorMessage) {
+    super(errorMessage);
+  }
 }

--- a/scuttlebutt-rpc/src/test/java/net/consensys/cava/scuttlebutt/rpc/mux/PatchworkIntegrationTest.java
+++ b/scuttlebutt-rpc/src/test/java/net/consensys/cava/scuttlebutt/rpc/mux/PatchworkIntegrationTest.java
@@ -41,7 +41,6 @@ import net.consensys.cava.scuttlebutt.rpc.RPCAsyncRequest;
 import net.consensys.cava.scuttlebutt.rpc.RPCFunction;
 import net.consensys.cava.scuttlebutt.rpc.RPCMessage;
 import net.consensys.cava.scuttlebutt.rpc.RPCStreamRequest;
-import net.consensys.cava.scuttlebutt.rpc.mux.exceptions.ConnectionClosedException;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -219,26 +218,22 @@ public class PatchworkIntegrationTest {
 
     RPCStreamRequest streamRequest = new RPCStreamRequest(new RPCFunction("createUserStream"), Arrays.asList(params));
 
-    try {
-      handler.openStream(streamRequest, (closeStream) -> new ScuttlebuttStreamHandler() {
-        @Override
-        public void onMessage(RPCMessage message) {
-          System.out.print(message.asString());
-        }
+    handler.openStream(streamRequest, (closeStream) -> new ScuttlebuttStreamHandler() {
+      @Override
+      public void onMessage(RPCMessage message) {
+        System.out.print(message.asString());
+      }
 
-        @Override
-        public void onStreamEnd() {
-          streamEnded.complete(null);
-        }
+      @Override
+      public void onStreamEnd() {
+        streamEnded.complete(null);
+      }
 
-        @Override
-        public void onStreamError(Exception ex) {
+      @Override
+      public void onStreamError(Exception ex) {
 
-        }
-      });
-    } catch (ConnectionClosedException e) {
-      throw e;
-    }
+      }
+    });
 
     // Wait until the stream is complete
     streamEnded.get();

--- a/scuttlebutt-rpc/src/test/java/net/consensys/cava/scuttlebutt/rpc/mux/PatchworkIntegrationTest.java
+++ b/scuttlebutt-rpc/src/test/java/net/consensys/cava/scuttlebutt/rpc/mux/PatchworkIntegrationTest.java
@@ -188,7 +188,7 @@ public class PatchworkIntegrationTest {
     AsyncResult<RPCHandler> onConnect =
         secureScuttlebuttVertxClient.connectTo(port, host, keyPair.publicKey(), (sender, terminationFn) -> {
 
-          return new RPCHandler(sender, terminationFn, new ObjectMapper(), loggerProvider);
+          return new RPCHandler(vertx, sender, terminationFn, new ObjectMapper(), loggerProvider);
         });
 
     return onConnect.get();


### PR DESCRIPTION
There is a thread deadlock condition in `RPCHandler` which prevents any further messages being sent or received.

* Thread 1 wants to send a request via `makeAsyncRequest` or `openStream` which are synchronized methods.
* This results in a call to `socket.write` in vertx as part of creating the request or stream.

* Thread 2, the vertx event loop wants to call back the `receivedMessage` handler. This is a synchronized method in `RPCHandler` , so vertx blocks because thread 1 is waiting on `socket.write` - however, `socket.write` cannot be serviced by the event loop since it's blocked.
